### PR TITLE
NDEV-1395 Fix empty error message on getTransactionReceipt when BlockhashNotFound error occurs

### DIFF
--- a/proxy/common_neon/errors.py
+++ b/proxy/common_neon/errors.py
@@ -29,12 +29,12 @@ class BlockedAccountsError(Exception):
 
 
 class NodeBehindError(Exception):
-    def __int__(self):
+    def __init__(self):
         super().__init__('The Solana node is not synchronized with a Solana cluster.')
 
 
 class SolanaUnavailableError(Exception):
-    def __int__(self):
+    def __init__(self):
         super().__init__('The Solana node is unavailable.')
 
 
@@ -43,20 +43,20 @@ class NonceTooLowError(Exception):
 
 
 class NoMoreRetriesError(Exception):
-    def __int__(self):
+    def __init__(self):
         super().__init__('The transaction is too complicated. No more retries to complete the Neon transaction.')
 
 
 class CUBudgetExceededError(Exception):
-    def __int__(self):
+    def __init__(self):
         super().__init__('The transaction is too complicated. Solana`s computing budget is exceeded.')
 
 
 class InvalidIxDataError(Exception):
-    def __int__(self):
+    def __init__(self):
         super().__init__('Wrong instruction data.')
 
 
 class RequireResizeIterError(Exception):
-    def __int__(self):
+    def __init__(self):
         super().__init__('Transaction requires resize iterations.')

--- a/proxy/common_neon/solana_tx_list_sender.py
+++ b/proxy/common_neon/solana_tx_list_sender.py
@@ -170,7 +170,11 @@ class SolTxListSender:
         }
 
         if tx_status in good_tx_status_set:
-            return self._get_tx_list_from_state(tx_state_list)
+            tx_list = self._get_tx_list_from_state(tx_state_list)
+            if tx_status == SolTxSendState.Status.BlockhashNotFoundError:
+                for tx in tx_list:
+                    tx.recent_blockhash = None
+            return tx_list
 
         error_tx_status_dict = {
             s.NodeBehindError: NodeBehindError,


### PR DESCRIPTION
1. Clearing `recent_blockhash` value in trx to force get actual value on sending
2. Fixed `__init__` method name in exception classes