### PR TITLE
NDEV-1405 Enable `null` value for `topic` in `eth_getLogs` method

### DIFF
--- a/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
+++ b/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
@@ -322,6 +322,9 @@ class NeonRpcApiWorker:
 
         if 'topics' in obj:
             raw_topic_list = obj['topics']
+            if raw_topic_list is None:
+                raw_topic_list = []
+
             if not isinstance(raw_topic_list, list):
                 raise InvalidParamError(message=f'bad topics {raw_topic_list}')
 


### PR DESCRIPTION
The `eth_getLogs` method allows using a `null` value for the `topic` parameter. In this case, behavior is the same as the empty list.