### PR TITLE
Wait for confirmed Solana txs using WebSockets instead of polling

### DIFF
--- a/docker-compose/docker-compose-test.yml
+++ b/docker-compose/docker-compose-test.yml
@@ -18,6 +18,7 @@ services:
       - net
     ports:
       - 8899:8899
+      - 8900:8900
     healthcheck:
       # Must be available from outside (calling without -u causes premature result)
       test: [ CMD-SHELL, "./wait-for-neon.sh" ]

--- a/proxy/common_neon/solana_interactor.py
+++ b/proxy/common_neon/solana_interactor.py
@@ -4,11 +4,13 @@ import base64
 from dataclasses import dataclass
 import itertools
 import json
+import threading
 import time
 from typing import Dict, Union, Any, List, Optional, Set, cast
 import logging
 import base58
 import requests
+import websockets.sync.client
 
 from .address import NeonAddress, neon_2program
 from .config import Config
@@ -544,36 +546,50 @@ class SolInteractor:
         return self._get_block_status(block_slot, finalized_block_info, response)
 
     def check_confirm_of_tx_sig_list(self, tx_sig_list: List[str],
-                                     commit_set: Set[SolCommit.Type],
-                                     valid_block_height: int) -> bool:
-        if len(tx_sig_list) == 0:
+                                     commitment: SolCommit,
+                                     timeout_sec: int) -> bool:
+        if not tx_sig_list:
             return True
 
-        block_height = self.get_block_height()
-        if block_height >= valid_block_height:
-            search_in_history = True
-        else:
-            search_in_history = False
+        all_sigs_confirmed = False
+        with websockets.sync.client.connect(self._config.solana_websocket_url) as websocket:
+            requests: Dict[int, bool] = {}
+            for tx_sig in tx_sig_list:
+                request = self._build_rpc_request('signatureSubscribe', tx_sig, {
+                    'commitment': commitment
+                })
+                requests[request['id']] = False
+                websocket.send(json.dumps(request))
 
-        opts = {
-            'searchTransactionHistory': search_in_history
-        }
-        limit = 100
+            timeout_timer = threading.Timer(timeout_sec, lambda: websocket.close())
+            timeout_timer.start()
 
-        while len(tx_sig_list) > 0:
-            (part_tx_sig_list, tx_sig_list) = (tx_sig_list[:limit], tx_sig_list[limit:])
-            response = self._send_rpc_request('getSignatureStatuses', part_tx_sig_list, opts)
+            subscriptions: Dict[int, bool] = {}
+            for response in websocket:
+                response = json.loads(response)
 
-            status_list = response.get('result', dict()).get('value', list())
-            if len(status_list) == 0:
-                return False
+                result = response.get('result', None)
+                id_ = response.get('id', None)
+                if result is not None and id_ is not None:
+                    requests[id_] = True
+                    subscriptions[result] = False
+                elif response.get('method', '') == 'signatureNotification':
+                    params = response.get('params', None)
+                    if params is not None:
+                        subscription = params.get('subscription', None)
+                        if subscription is not None:
+                            subscriptions[subscription] = True
 
-            for status in status_list:
-                if not status:
-                    return False
-                elif status.get('confirmationStatus', '') not in commit_set:
-                    return False
-        return True
+                if (len(tx_sig_list) == len(requests) and len(requests) == len(subscriptions)
+                    and all(requests.values()) and all(subscriptions.values())):
+                    all_sigs_confirmed = True
+                    websocket.close()
+                    break
+
+            timeout_timer.cancel()
+            timeout_timer.join()
+
+        return all_sigs_confirmed
 
     def get_tx_receipt_list(self, tx_sig_list: List[str],
                             commitment: SolCommit.Type) -> List[Optional[Dict[str, Any]]]:

--- a/proxy/common_neon/solana_interactor.py
+++ b/proxy/common_neon/solana_interactor.py
@@ -546,8 +546,8 @@ class SolInteractor:
         return self._get_block_status(block_slot, finalized_block_info, response)
 
     def check_confirm_of_tx_sig_list(self, tx_sig_list: List[str],
-                                     commitment: SolCommit,
-                                     timeout_sec: int) -> bool:
+                                     commitment: SolCommit.Type,
+                                     timeout_sec: float) -> bool:
         if not tx_sig_list:
             return True
 
@@ -580,7 +580,7 @@ class SolInteractor:
                         if subscription is not None:
                             subscriptions[subscription] = True
 
-                if (len(tx_sig_list) == len(requests) and len(requests) == len(subscriptions)
+                if (len(tx_sig_list) == len(subscriptions)
                     and all(requests.values()) and all(subscriptions.values())):
                     all_sigs_confirmed = True
                     websocket.close()

--- a/proxy/common_neon/solana_tx_list_sender.py
+++ b/proxy/common_neon/solana_tx_list_sender.py
@@ -374,19 +374,17 @@ class SolTxListSender:
             tx_sig_list.append(tx_state.sig)
             tx_list.append(tx_state.tx)
 
-        self._wait_for_confirm_of_tx_list(tx_sig_list)
+        self._solana.check_confirm_of_tx_sig_list(
+            tx_sig_list,
+            SolCommit.Confirmed,
+            self._config.confirm_timeout_sec)
+
         self._get_tx_receipt_list(tx_sig_list, tx_list)
 
     def _get_tx_receipt_list(self, tx_sig_list: Optional[List[str]], tx_list: List[SolTx]) -> None:
         tx_receipt_list = self._solana.get_tx_receipt_list(tx_sig_list, SolCommit.Confirmed)
         for tx, tx_receipt in zip(tx_list, tx_receipt_list):
             self._add_tx_state(tx, tx_receipt, SolTxSendState.Status.NoReceiptError)
-
-    def _wait_for_confirm_of_tx_list(self, tx_sig_list: List[str]) -> None:
-        self._solana.check_confirm_of_tx_sig_list(
-            tx_sig_list,
-            SolCommit.Confirmed,
-            self._config.confirm_timeout_sec)
 
     @dataclass(frozen=True)
     class _DecodeResult:

--- a/proxy/common_neon/solana_tx_list_sender.py
+++ b/proxy/common_neon/solana_tx_list_sender.py
@@ -75,7 +75,6 @@ class SolTxSendState:
 
 
 class SolTxListSender:
-    _commit_set = SolCommit.upper_set(SolCommit.Confirmed)
     _big_block_height = 2 ** 64 - 1
     _big_block_slot = 2 ** 64 - 1
 
@@ -371,13 +370,11 @@ class SolTxListSender:
 
         tx_sig_list: List[str] = list()
         tx_list: List[SolTx] = list()
-        valid_block_height = self._big_block_height
         for tx_state in tx_state_list:
             tx_sig_list.append(tx_state.sig)
             tx_list.append(tx_state.tx)
-            valid_block_height = min(valid_block_height, tx_state.valid_block_height)
 
-        self._wait_for_confirm_of_tx_list(tx_sig_list, valid_block_height)
+        self._wait_for_confirm_of_tx_list(tx_sig_list)
         self._get_tx_receipt_list(tx_sig_list, tx_list)
 
     def _get_tx_receipt_list(self, tx_sig_list: Optional[List[str]], tx_list: List[SolTx]) -> None:
@@ -385,19 +382,11 @@ class SolTxListSender:
         for tx, tx_receipt in zip(tx_list, tx_receipt_list):
             self._add_tx_state(tx, tx_receipt, SolTxSendState.Status.NoReceiptError)
 
-    def _wait_for_confirm_of_tx_list(self, tx_sig_list: List[str], valid_block_height: int) -> None:
-        confirm_timeout = self._config.confirm_timeout_sec
-        confirm_check_delay = float(self._config.confirm_check_msec) / 1000
-        elapsed_time = 0.0
-        commit_set = self._commit_set
-
-        while elapsed_time < confirm_timeout:
-            is_confirmed = self._solana.check_confirm_of_tx_sig_list(tx_sig_list, commit_set, valid_block_height)
-            if is_confirmed:
-                return
-
-            time.sleep(confirm_check_delay)
-            elapsed_time += confirm_check_delay
+    def _wait_for_confirm_of_tx_list(self, tx_sig_list: List[str]) -> None:
+        self._solana.check_confirm_of_tx_sig_list(
+            tx_sig_list,
+            SolCommit.Confirmed,
+            self._config.confirm_timeout_sec)
 
     @dataclass(frozen=True)
     class _DecodeResult:

--- a/proxy/testing/testing_helpers.py
+++ b/proxy/testing/testing_helpers.py
@@ -178,20 +178,8 @@ class SolClient(SolInteractor):
         tx_sig = sent_resp.result
         print(f'-> success send solana tx {tx.name}: {tx_sig}')
 
-        valid_block_height = recent_resp.last_valid_block_height
-        confirm_set = SolCommit.upper_set(SolCommit.Confirmed)
-
-        elapsed_time = 0.0
-        confirm_timeout = 32 * 0.4
-        confirm_check_delay = 0.1
-
-        while elapsed_time < confirm_timeout:
-            is_confirmed = self.check_confirm_of_tx_sig_list([tx_sig], confirm_set, valid_block_height)
-            if is_confirmed:
-                break
-
-            time.sleep(confirm_check_delay)
-            elapsed_time += confirm_check_delay
+        confirm_timeout_sec = 32 * 0.4
+        self.check_confirm_of_tx_sig_list([tx_sig], SolCommit.Confirmed, confirm_timeout_sec)
 
         tx_receipt = self.get_tx_receipt_list([tx_sig], SolCommit.Confirmed)
         print(f'-> solana receipt: {tx_receipt}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ web3==6.3.0
 aioprometheus==23.3.0
 singleton-decorator==1.0.0
 clickhouse-connect==0.5.24
+websockets==11.0.3


### PR DESCRIPTION
Fixes neonevm/proxy-model.py#1090.

This replaces the existing implementation, which polls the Solana tx periodically in a loop, with one that subscribes directly to the WebSockets API. I chose to use `threading` as the current code doesn't use `async`, but ideally the entire file uses `async` so we could switch to the `async` version of the `websockets` API.

I've tested the functions separately outside of the proxy, but need help with testing this within the proxy, so any guidance here would be helpful.