### PR TITLE
feat: allow operator fee 100%

### DIFF
--- a/proxy/common_neon/config.py
+++ b/proxy/common_neon/config.py
@@ -34,76 +34,110 @@ class Config(DBConfig):
 
     def __init__(self):
         super().__init__()
-        self._solana_url = os.environ.get("SOLANA_URL", "http://localhost:8899")
-        self._solana_websocket_url = parse_solana_websocket_url(self._solana_url)
+        self._solana_url = os.environ.get(
+            "SOLANA_URL", "http://localhost:8899")
+        self._solana_websocket_url = parse_solana_websocket_url(
+            self._solana_url)
         self._pp_solana_url = os.environ.get("PP_SOLANA_URL", self._solana_url)
         self._evm_program_id = SolPubKey.from_string(EVM_LOADER_ID)
         self._mempool_capacity = self._env_int("MEMPOOL_CAPACITY", 10, 4096)
-        self._mempool_executor_limit_cnt = self._env_int('MEMPOOL_EXECUTOR_LIMIT_CNT', 4, 1024)
-        self._mempool_cache_life_sec = self._env_int('MEMPOOL_CACHE_LIFE_SEC', 15, 30 * 60)
-        self._accept_reverted_tx_into_mempool = self._env_bool('ACCEPT_REVERTED_TX_INTO_MEMPOOL', False)
-        self._holder_size = self._env_int("HOLDER_SIZE", 1024, 262144)  # 256*1024
-        self._min_op_balance_to_warn = self._env_int("MIN_OPERATOR_BALANCE_TO_WARN", 9000000000, 9000000000)
-        self._min_op_balance_to_err = self._env_int("MIN_OPERATOR_BALANCE_TO_ERR", 1000000000, 1000000000)
+        self._mempool_executor_limit_cnt = self._env_int(
+            'MEMPOOL_EXECUTOR_LIMIT_CNT', 4, 1024)
+        self._mempool_cache_life_sec = self._env_int(
+            'MEMPOOL_CACHE_LIFE_SEC', 15, 30 * 60)
+        self._accept_reverted_tx_into_mempool = self._env_bool(
+            'ACCEPT_REVERTED_TX_INTO_MEMPOOL', False)
+        self._holder_size = self._env_int(
+            "HOLDER_SIZE", 1024, 262144)  # 256*1024
+        self._min_op_balance_to_warn = self._env_int(
+            "MIN_OPERATOR_BALANCE_TO_WARN", 9000000000, 9000000000)
+        self._min_op_balance_to_err = self._env_int(
+            "MIN_OPERATOR_BALANCE_TO_ERR", 1000000000, 1000000000)
         self._perm_account_id = self._env_int("PERM_ACCOUNT_ID", 1, 1)
         self._perm_account_limit = self._env_int("PERM_ACCOUNT_LIMIT", 1, 2)
-        self._recheck_used_resource_sec = self._env_int('RECHECK_USED_RESOURCE_SEC', 10, 60)
-        self._recheck_resource_after_uses_cnt = self._env_int("RECHECK_RESOURCE_AFTER_USES_CNT", 10, 60)
+        self._recheck_used_resource_sec = self._env_int(
+            'RECHECK_USED_RESOURCE_SEC', 10, 60)
+        self._recheck_resource_after_uses_cnt = self._env_int(
+            "RECHECK_RESOURCE_AFTER_USES_CNT", 10, 60)
         self._retry_on_fail = self._env_int("RETRY_ON_FAIL", 1, 10)
         self._enable_private_api = self._env_bool("ENABLE_PRIVATE_API", False)
         self._enable_send_tx_api = self._env_bool("ENABLE_SEND_TX_API", True)
-        self._use_earliest_block_if_0_passed = self._env_bool("USE_EARLIEST_BLOCK_IF_0_PASSED", False)
-        self._account_permission_update_int = self._env_int("ACCOUNT_PERMISSION_UPDATE_INT", 10, 60 * 5)
-        self._allow_underpriced_tx_wo_chainid = self._env_bool('ALLOW_UNDERPRICED_TX_WITHOUT_CHAINID', False)
+        self._use_earliest_block_if_0_passed = self._env_bool(
+            "USE_EARLIEST_BLOCK_IF_0_PASSED", False)
+        self._account_permission_update_int = self._env_int(
+            "ACCOUNT_PERMISSION_UPDATE_INT", 10, 60 * 5)
+        self._allow_underpriced_tx_wo_chainid = self._env_bool(
+            'ALLOW_UNDERPRICED_TX_WITHOUT_CHAINID', False)
         self._operator_fee = self._env_decimal('OPERATOR_FEE', "0.1")
-        self._gas_price_slippage = self._env_decimal('GAS_PRICE_SLIPPAGE', "0.01")
-        self._slot_processing_delay = self._env_int("SLOT_PROCESSING_DELAY", 0, 0)
-        self._min_gas_price = self._env_int("MINIMAL_GAS_PRICE", 0, 1) * (10 ** 9)
-        self._min_wo_chainid_gas_price = self._env_int("MINIMAL_WO_CHAINID_GAS_PRICE", 0, 10) * (10 ** 9)
-        self._gas_less_tx_max_nonce = self._env_int("GAS_LESS_MAX_TX_NONCE", 0, 5)
-        self._gas_less_tx_max_gas = self._env_int("GAS_LESS_MAX_GAS", 0, 20_000_000)  # Estimated gas on Mora = 18 mln
+        self._gas_price_slippage = self._env_decimal(
+            'GAS_PRICE_SLIPPAGE', "0.01")
+        self._slot_processing_delay = self._env_int(
+            "SLOT_PROCESSING_DELAY", 0, 0)
+        self._min_gas_price = self._env_int(
+            "MINIMAL_GAS_PRICE", 0, 1) * (10 ** 9)
+        self._min_wo_chainid_gas_price = self._env_int(
+            "MINIMAL_WO_CHAINID_GAS_PRICE", 0, 10) * (10 ** 9)
+        self._gas_less_tx_max_nonce = self._env_int(
+            "GAS_LESS_MAX_TX_NONCE", 0, 5)
+        self._gas_less_tx_max_gas = self._env_int(
+            "GAS_LESS_MAX_GAS", 0, 20_000_000)  # Estimated gas on Mora = 18 mln
         self._neon_price_usd = Decimal('0.25')
         self._start_slot = os.environ.get('START_SLOT', '0')
-        self._indexer_parallel_request_cnt = self._env_int("INDEXER_PARALLEL_REQUEST_COUNT", 1, 10)
+        self._indexer_parallel_request_cnt = self._env_int(
+            "INDEXER_PARALLEL_REQUEST_COUNT", 1, 10)
         self._indexer_poll_cnt = self._env_int("INDEXER_POLL_COUNT", 1, 1000)
-        self._indexer_log_skip_cnt = self._env_int("INDEXER_LOG_SKIP_COUNT", 1, 1000)
+        self._indexer_log_skip_cnt = self._env_int(
+            "INDEXER_LOG_SKIP_COUNT", 1, 1000)
         self._indexer_check_msec = self._env_int('INDEXER_CHECK_MSEC', 50, 200)
-        self._max_tx_account_cnt = self._env_int("MAX_TX_ACCOUNT_COUNT", 20, 62)
+        self._max_tx_account_cnt = self._env_int(
+            "MAX_TX_ACCOUNT_COUNT", 20, 62)
         self._fuzz_fail_pct = self._env_int("FUZZ_FAIL_PCT", 0, 0)
-        self._confirm_timeout_sec = self._env_int("CONFIRM_TIMEOUT_SEC", 4, math.ceil(self._min_finalize_sec))
-        self._max_evm_step_cnt_emulate = self._env_int("MAX_EVM_STEP_COUNT_TO_EMULATE", 1000, 500000)
+        self._confirm_timeout_sec = self._env_int(
+            "CONFIRM_TIMEOUT_SEC", 4, math.ceil(self._min_finalize_sec))
+        self._max_evm_step_cnt_emulate = self._env_int(
+            "MAX_EVM_STEP_COUNT_TO_EMULATE", 1000, 500000)
         self._neon_cli_timeout = self._env_decimal("NEON_CLI_TIMEOUT", "2.5")
         self._neon_cli_debug_log = self._env_bool("NEON_CLI_DEBUG_LOG", False)
-        self._stuck_obj_blockout = self._env_int('STUCK_OBJECT_BLOCKOUT', 16, 64)
-        self._stuck_obj_validate_blockout = self._env_int('STUCK_OBJECT_VALIDATE_BLOCKOUT', 512, 1024)
-        self._alt_freeing_depth = self._env_int('ALT_FREEING_DEPTH', 512, 512 + 16)
+        self._stuck_obj_blockout = self._env_int(
+            'STUCK_OBJECT_BLOCKOUT', 16, 64)
+        self._stuck_obj_validate_blockout = self._env_int(
+            'STUCK_OBJECT_VALIDATE_BLOCKOUT', 512, 1024)
+        self._alt_freeing_depth = self._env_int(
+            'ALT_FREEING_DEPTH', 512, 512 + 16)
         self._gather_statistics = self._env_bool("GATHER_STATISTICS", False)
         self._hvac_url = os.environ.get('HVAC_URL', None)
         self._hvac_token = os.environ.get('HVAC_TOKEN', None)
         self._hvac_mount = os.environ.get('HVAC_MOUNT', None)
         self._hvac_path = os.environ.get('HVAC_PATH', '')
-        self._genesis_timestamp = self._env_int('GENESIS_BLOCK_TIMESTAMP', 0, 0)
-        self._commit_level = os.environ.get('COMMIT_LEVEL', SolCommit.Confirmed)
+        self._genesis_timestamp = self._env_int(
+            'GENESIS_BLOCK_TIMESTAMP', 0, 0)
+        self._commit_level = os.environ.get(
+            'COMMIT_LEVEL', SolCommit.Confirmed)
         self._ch_dsn_list = os.environ.get('CLICKHOUSE_DSN_LIST', '')
 
         pyth_mapping_account = os.environ.get('PYTH_MAPPING_ACCOUNT', None)
         if pyth_mapping_account is not None:
-            self._pyth_mapping_account = SolPubKey.from_string(pyth_mapping_account)
+            self._pyth_mapping_account = SolPubKey.from_string(
+                pyth_mapping_account)
         else:
             self._pyth_mapping_account = None
-        self._update_pyth_mapping_period_sec = self._env_int('UPDATE_PYTH_MAPPING_PERIOD_SEC', 10, 60 * 60)
+        self._update_pyth_mapping_period_sec = self._env_int(
+            'UPDATE_PYTH_MAPPING_PERIOD_SEC', 10, 60 * 60)
 
         op_acct_list = os.environ.get('OPERATOR_ACCOUNT_LIST', '')
-        self._op_acct_set = set([acct for acct in op_acct_list.split(' ;,') if len(acct) > 0])
+        self._op_acct_set = set(
+            [acct for acct in op_acct_list.split(' ;,') if len(acct) > 0])
 
         self._validate()
 
     def _validate(self) -> None:
         self._commit_level = SolCommit.Type(self._commit_level.lower())
-        assert SolCommit.level(self._commit_level) >= SolCommit.level(SolCommit.Confirmed)
+        assert SolCommit.level(self._commit_level) >= SolCommit.level(
+            SolCommit.Confirmed)
 
-        assert (self._operator_fee > 0) and (self._operator_fee < 1)
-        assert (self._gas_price_slippage >= 0) and (self._gas_price_slippage < 1)
+        assert (self._operator_fee > 0) and (self._operator_fee <= 1)
+        assert (self._gas_price_slippage >= 0) and (
+            self._gas_price_slippage < 1)
         assert (self._slot_processing_delay < 32)
         assert (self._fuzz_fail_pct >= 0) and (self._fuzz_fail_pct < 100)
 

--- a/proxy/common_neon/config.py
+++ b/proxy/common_neon/config.py
@@ -34,110 +34,76 @@ class Config(DBConfig):
 
     def __init__(self):
         super().__init__()
-        self._solana_url = os.environ.get(
-            "SOLANA_URL", "http://localhost:8899")
-        self._solana_websocket_url = parse_solana_websocket_url(
-            self._solana_url)
+        self._solana_url = os.environ.get("SOLANA_URL", "http://localhost:8899")
+        self._solana_websocket_url = parse_solana_websocket_url(self._solana_url)
         self._pp_solana_url = os.environ.get("PP_SOLANA_URL", self._solana_url)
         self._evm_program_id = SolPubKey.from_string(EVM_LOADER_ID)
         self._mempool_capacity = self._env_int("MEMPOOL_CAPACITY", 10, 4096)
-        self._mempool_executor_limit_cnt = self._env_int(
-            'MEMPOOL_EXECUTOR_LIMIT_CNT', 4, 1024)
-        self._mempool_cache_life_sec = self._env_int(
-            'MEMPOOL_CACHE_LIFE_SEC', 15, 30 * 60)
-        self._accept_reverted_tx_into_mempool = self._env_bool(
-            'ACCEPT_REVERTED_TX_INTO_MEMPOOL', False)
-        self._holder_size = self._env_int(
-            "HOLDER_SIZE", 1024, 262144)  # 256*1024
-        self._min_op_balance_to_warn = self._env_int(
-            "MIN_OPERATOR_BALANCE_TO_WARN", 9000000000, 9000000000)
-        self._min_op_balance_to_err = self._env_int(
-            "MIN_OPERATOR_BALANCE_TO_ERR", 1000000000, 1000000000)
+        self._mempool_executor_limit_cnt = self._env_int('MEMPOOL_EXECUTOR_LIMIT_CNT', 4, 1024)
+        self._mempool_cache_life_sec = self._env_int('MEMPOOL_CACHE_LIFE_SEC', 15, 30 * 60)
+        self._accept_reverted_tx_into_mempool = self._env_bool('ACCEPT_REVERTED_TX_INTO_MEMPOOL', False)
+        self._holder_size = self._env_int("HOLDER_SIZE", 1024, 262144)  # 256*1024
+        self._min_op_balance_to_warn = self._env_int("MIN_OPERATOR_BALANCE_TO_WARN", 9000000000, 9000000000)
+        self._min_op_balance_to_err = self._env_int("MIN_OPERATOR_BALANCE_TO_ERR", 1000000000, 1000000000)
         self._perm_account_id = self._env_int("PERM_ACCOUNT_ID", 1, 1)
         self._perm_account_limit = self._env_int("PERM_ACCOUNT_LIMIT", 1, 2)
-        self._recheck_used_resource_sec = self._env_int(
-            'RECHECK_USED_RESOURCE_SEC', 10, 60)
-        self._recheck_resource_after_uses_cnt = self._env_int(
-            "RECHECK_RESOURCE_AFTER_USES_CNT", 10, 60)
+        self._recheck_used_resource_sec = self._env_int('RECHECK_USED_RESOURCE_SEC', 10, 60)
+        self._recheck_resource_after_uses_cnt = self._env_int("RECHECK_RESOURCE_AFTER_USES_CNT", 10, 60)
         self._retry_on_fail = self._env_int("RETRY_ON_FAIL", 1, 10)
         self._enable_private_api = self._env_bool("ENABLE_PRIVATE_API", False)
         self._enable_send_tx_api = self._env_bool("ENABLE_SEND_TX_API", True)
-        self._use_earliest_block_if_0_passed = self._env_bool(
-            "USE_EARLIEST_BLOCK_IF_0_PASSED", False)
-        self._account_permission_update_int = self._env_int(
-            "ACCOUNT_PERMISSION_UPDATE_INT", 10, 60 * 5)
-        self._allow_underpriced_tx_wo_chainid = self._env_bool(
-            'ALLOW_UNDERPRICED_TX_WITHOUT_CHAINID', False)
+        self._use_earliest_block_if_0_passed = self._env_bool("USE_EARLIEST_BLOCK_IF_0_PASSED", False)
+        self._account_permission_update_int = self._env_int("ACCOUNT_PERMISSION_UPDATE_INT", 10, 60 * 5)
+        self._allow_underpriced_tx_wo_chainid = self._env_bool('ALLOW_UNDERPRICED_TX_WITHOUT_CHAINID', False)
         self._operator_fee = self._env_decimal('OPERATOR_FEE', "0.1")
-        self._gas_price_slippage = self._env_decimal(
-            'GAS_PRICE_SLIPPAGE', "0.01")
-        self._slot_processing_delay = self._env_int(
-            "SLOT_PROCESSING_DELAY", 0, 0)
-        self._min_gas_price = self._env_int(
-            "MINIMAL_GAS_PRICE", 0, 1) * (10 ** 9)
-        self._min_wo_chainid_gas_price = self._env_int(
-            "MINIMAL_WO_CHAINID_GAS_PRICE", 0, 10) * (10 ** 9)
-        self._gas_less_tx_max_nonce = self._env_int(
-            "GAS_LESS_MAX_TX_NONCE", 0, 5)
-        self._gas_less_tx_max_gas = self._env_int(
-            "GAS_LESS_MAX_GAS", 0, 20_000_000)  # Estimated gas on Mora = 18 mln
+        self._gas_price_slippage = self._env_decimal('GAS_PRICE_SLIPPAGE', "0.01")
+        self._slot_processing_delay = self._env_int("SLOT_PROCESSING_DELAY", 0, 0)
+        self._min_gas_price = self._env_int("MINIMAL_GAS_PRICE", 0, 1) * (10 ** 9)
+        self._min_wo_chainid_gas_price = self._env_int("MINIMAL_WO_CHAINID_GAS_PRICE", 0, 10) * (10 ** 9)
+        self._gas_less_tx_max_nonce = self._env_int("GAS_LESS_MAX_TX_NONCE", 0, 5)
+        self._gas_less_tx_max_gas = self._env_int("GAS_LESS_MAX_GAS", 0, 20_000_000)  # Estimated gas on Mora = 18 mln
         self._neon_price_usd = Decimal('0.25')
         self._start_slot = os.environ.get('START_SLOT', '0')
-        self._indexer_parallel_request_cnt = self._env_int(
-            "INDEXER_PARALLEL_REQUEST_COUNT", 1, 10)
+        self._indexer_parallel_request_cnt = self._env_int("INDEXER_PARALLEL_REQUEST_COUNT", 1, 10)
         self._indexer_poll_cnt = self._env_int("INDEXER_POLL_COUNT", 1, 1000)
-        self._indexer_log_skip_cnt = self._env_int(
-            "INDEXER_LOG_SKIP_COUNT", 1, 1000)
+        self._indexer_log_skip_cnt = self._env_int("INDEXER_LOG_SKIP_COUNT", 1, 1000)
         self._indexer_check_msec = self._env_int('INDEXER_CHECK_MSEC', 50, 200)
-        self._max_tx_account_cnt = self._env_int(
-            "MAX_TX_ACCOUNT_COUNT", 20, 62)
+        self._max_tx_account_cnt = self._env_int("MAX_TX_ACCOUNT_COUNT", 20, 62)
         self._fuzz_fail_pct = self._env_int("FUZZ_FAIL_PCT", 0, 0)
-        self._confirm_timeout_sec = self._env_int(
-            "CONFIRM_TIMEOUT_SEC", 4, math.ceil(self._min_finalize_sec))
-        self._max_evm_step_cnt_emulate = self._env_int(
-            "MAX_EVM_STEP_COUNT_TO_EMULATE", 1000, 500000)
+        self._confirm_timeout_sec = self._env_int("CONFIRM_TIMEOUT_SEC", 4, math.ceil(self._min_finalize_sec))
+        self._max_evm_step_cnt_emulate = self._env_int("MAX_EVM_STEP_COUNT_TO_EMULATE", 1000, 500000)
         self._neon_cli_timeout = self._env_decimal("NEON_CLI_TIMEOUT", "2.5")
         self._neon_cli_debug_log = self._env_bool("NEON_CLI_DEBUG_LOG", False)
-        self._stuck_obj_blockout = self._env_int(
-            'STUCK_OBJECT_BLOCKOUT', 16, 64)
-        self._stuck_obj_validate_blockout = self._env_int(
-            'STUCK_OBJECT_VALIDATE_BLOCKOUT', 512, 1024)
-        self._alt_freeing_depth = self._env_int(
-            'ALT_FREEING_DEPTH', 512, 512 + 16)
+        self._stuck_obj_blockout = self._env_int('STUCK_OBJECT_BLOCKOUT', 16, 64)
+        self._stuck_obj_validate_blockout = self._env_int('STUCK_OBJECT_VALIDATE_BLOCKOUT', 512, 1024)
+        self._alt_freeing_depth = self._env_int('ALT_FREEING_DEPTH', 512, 512 + 16)
         self._gather_statistics = self._env_bool("GATHER_STATISTICS", False)
         self._hvac_url = os.environ.get('HVAC_URL', None)
         self._hvac_token = os.environ.get('HVAC_TOKEN', None)
         self._hvac_mount = os.environ.get('HVAC_MOUNT', None)
         self._hvac_path = os.environ.get('HVAC_PATH', '')
-        self._genesis_timestamp = self._env_int(
-            'GENESIS_BLOCK_TIMESTAMP', 0, 0)
-        self._commit_level = os.environ.get(
-            'COMMIT_LEVEL', SolCommit.Confirmed)
+        self._genesis_timestamp = self._env_int('GENESIS_BLOCK_TIMESTAMP', 0, 0)
+        self._commit_level = os.environ.get('COMMIT_LEVEL', SolCommit.Confirmed)
         self._ch_dsn_list = os.environ.get('CLICKHOUSE_DSN_LIST', '')
 
         pyth_mapping_account = os.environ.get('PYTH_MAPPING_ACCOUNT', None)
         if pyth_mapping_account is not None:
-            self._pyth_mapping_account = SolPubKey.from_string(
-                pyth_mapping_account)
+            self._pyth_mapping_account = SolPubKey.from_string(pyth_mapping_account)
         else:
             self._pyth_mapping_account = None
-        self._update_pyth_mapping_period_sec = self._env_int(
-            'UPDATE_PYTH_MAPPING_PERIOD_SEC', 10, 60 * 60)
+        self._update_pyth_mapping_period_sec = self._env_int('UPDATE_PYTH_MAPPING_PERIOD_SEC', 10, 60 * 60)
 
         op_acct_list = os.environ.get('OPERATOR_ACCOUNT_LIST', '')
-        self._op_acct_set = set(
-            [acct for acct in op_acct_list.split(' ;,') if len(acct) > 0])
+        self._op_acct_set = set([acct for acct in op_acct_list.split(' ;,') if len(acct) > 0])
 
         self._validate()
 
     def _validate(self) -> None:
         self._commit_level = SolCommit.Type(self._commit_level.lower())
-        assert SolCommit.level(self._commit_level) >= SolCommit.level(
-            SolCommit.Confirmed)
+        assert SolCommit.level(self._commit_level) >= SolCommit.level(SolCommit.Confirmed)
 
         assert (self._operator_fee > 0) and (self._operator_fee <= 1)
-        assert (self._gas_price_slippage >= 0) and (
-            self._gas_price_slippage < 1)
+        assert (self._gas_price_slippage >= 0) and (self._gas_price_slippage < 1)
         assert (self._slot_processing_delay < 32)
         assert (self._fuzz_fail_pct >= 0) and (self._fuzz_fail_pct < 100)
 


### PR DESCRIPTION
Currently, neon-proxy fails to launch if the operator fee is configured as `1` which means 100% operator fee, which is misconduct with the official [doc](https://docs.neonfoundation.io/docs/operating/transaction-gas#gas-price-the-operator-fee ) where recommended to set `PRX_OPERATOR_FEE=1`. This PR fixes the problem.