### PR TITLE
Enhance compatibility with ethclient 

### DIFF
--- a/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
+++ b/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
@@ -500,11 +500,13 @@ class NeonRpcApiWorker:
 
         # by default - maximum BPF cycles in Solana block
         max_gas_used = max(48_000_000, total_gas_used)
+        empty_root = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
+        root = empty_root if len(tx_list) == 0 else '0x' + '0' * 63 + '1'
 
         result = {
             "logsBloom": '0x' + '0' * 512,
-            "transactionsRoot": '0x' + '0' * 63 + '1',
-            "receiptsRoot": '0x' + '0' * 63 + '1',
+            "transactionsRoot": root,
+            "receiptsRoot": root,
             "stateRoot": '0x' + '0' * 63 + '1',
 
 


### PR DESCRIPTION
Please refer to https://github.com/ethereum/go-ethereum/blob/b058cf454b3bdc7e770e2b3cec83a0bcb48f55ee/ethclient/ethclient.go#L140C1-L151C2
It will check the empty hash with the transactionsRoot. 


ref: https://github.com/neonlabsorg/neon-proxy/issues/56