### PR TITLE
fix ci notification condition

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -356,8 +356,10 @@ jobs:
       - build-image
     if: |
        failure() &&
-        (github.ref_name == 'develop' ||
-          github.ref_name == 'master' ||
+        (github.event.inputs.neon_evm_branch == 'refs/heads/develop' ||
+          github.event.inputs.neon_evm_branch == 'refs/heads/master' ||
+          (github.ref_name == 'develop' && github.event.inputs.neon_evm_commit == '') ||
+          (github.ref_name == 'master' && github.event.inputs.neon_evm_commit == '') ||
           (needs.build-image.outputs.is_version_proxy_branch == 'true' && github.event.inputs.neon_evm_commit == '') ||
           startsWith(github.ref , 'refs/tags/'))
     steps:


### PR DESCRIPTION
Changed a condition so asnot to send notifications for the case when PR created on feature branch in neon-evm repo