### PR TITLE
Benchmark tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -273,7 +273,7 @@ jobs:
         run: |
           docker exec -i ${{ env.CONTAINER }} python3 ./clickfile.py run oz \
             --network ${{ env.NETWORK_NAME }} \
-            --jobs 8 \
+            --jobs 110 \
             --users 10
       - name: Print OpenZeppelin report
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -257,7 +257,7 @@ jobs:
       NETWORK_NAME: aws_custom
     steps:
       - name: Pull docker image
-        run: docker pull ${{ env.NEON_TEST_IMAGE }}:${{ needs.build-image.outputs.neon_test_tag }}
+        run: docker pull ${{ env.NEON_TEST_IMAGE }}:4485c15b47aaffaa3c39d22b7d2fa6d2ed2ce751
       - name: Run docker container
         run: |
           docker run -i -e PROXY_IP=${{env.PROXY_IP}} \
@@ -310,7 +310,7 @@ jobs:
     steps:
       - name: Run docker container
         run: |
-          image="${{ env.NEON_TEST_IMAGE }}:${{ needs.build-image.outputs.neon_test_tag }}"
+          image="${{ env.NEON_TEST_IMAGE }}:4485c15b47aaffaa3c39d22b7d2fa6d2ed2ce751"
           docker pull $image
           docker run -i -d -e PROXY_IP=${{ env.PROXY_IP }} -e SOLANA_IP=${{ env.SOLANA_IP }} \
           --name=${{ env.CONTAINER }} $image /bin/bash
@@ -363,7 +363,7 @@ jobs:
     steps:
       - name: Run docker container
         run: |
-          image="${{ env.NEON_TEST_IMAGE }}:${{ needs.build-image.outputs.neon_test_tag }}"
+          image="${{ env.NEON_TEST_IMAGE }}:4485c15b47aaffaa3c39d22b7d2fa6d2ed2ce751"
           docker pull $image
           docker run -i -d -e PROXY_IP=${{ env.PROXY_IP }} -e SOLANA_IP=${{ env.SOLANA_IP }} \
           --name=${{ env.CONTAINER }} $image /bin/bash

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -417,8 +417,8 @@ jobs:
           TF_VAR_branch: ${{ steps.vars.outputs.bname }}
         run: |
           python3 ./.github/workflows/deploy.py destroy_terraform \
-          --run_number=${{env.GITHUB_RUN_NUMBER}} \
-          --proxy_tag=${{ needs.build-image.outputs.proxy_tag }}
+          --run_number=2632 \
+          --proxy_tag=162a514266efbb6f99a66a3b66f62dc163cbef31-2c0a080c02
   finalize-image:
     runs-on: build-runner
     needs:


### PR DESCRIPTION
OpenZeppelin tests:
- [48min 44s](https://github.com/neonlabsorg/proxy-model.py/actions/runs/7150592740/job/19474064113)