### PR TITLE
Minor fixes to run locally

### DIFF
--- a/.github/workflows/deploy.py
+++ b/.github/workflows/deploy.py
@@ -69,22 +69,10 @@ terraform = Terraform(working_dir=pathlib.Path(
 
 
 def docker_compose(args: str):
-    get_version = f'docker-compose --version'
-
-    click.echo(f"run command: {get_version}")
-    out = subprocess.run(get_version, capture_output=True, shell=True)
-    click.echo("return code: " + str(out.returncode))
-
-    if out.returncode != 0:
-        raise RuntimeError(f"Command {get_version} failed. Err: {out.stderr}")
-
-    version = out.stdout.decode('utf-8').split(' ')[3]
-    command = f'docker-compose {args}' if version < '1.20' else f'docker-compose --compatibility {args}'
-
+    command = f'docker-compose --compatibility {args}'
     click.echo(f"run command: {command}")
     out = subprocess.run(command, shell=True)
     click.echo("return code: " + str(out.returncode))
-
     if out.returncode != 0:
         raise RuntimeError(f"Command {command} failed. Err: {out.stderr}")
 

--- a/.github/workflows/deploy.py
+++ b/.github/workflows/deploy.py
@@ -69,10 +69,22 @@ terraform = Terraform(working_dir=pathlib.Path(
 
 
 def docker_compose(args: str):
-    command = f'docker-compose {args}'
+    get_version = f'docker-compose --version'
+
+    click.echo(f"run command: {get_version}")
+    out = subprocess.run(get_version, capture_output=True, shell=True)
+    click.echo("return code: " + str(out.returncode))
+
+    if out.returncode != 0:
+        raise RuntimeError(f"Command {get_version} failed. Err: {out.stderr}")
+
+    version = out.stdout.decode('utf-8').split(' ')[3]
+    command = f'docker-compose {args}' if version < '1.20' else f'docker-compose --compatibility {args}'
+
     click.echo(f"run command: {command}")
     out = subprocess.run(command, shell=True)
     click.echo("return code: " + str(out.returncode))
+
     if out.returncode != 0:
         raise RuntimeError(f"Command {command} failed. Err: {out.stderr}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+click==8.1.7
+docker==7.0.0
+paramiko==3.4.0
+python-terraform==0.10.1
+scp==0.14.5
 typing-extensions==4.9.0
 ecdsa==0.18.0
 pysha3==1.0.2


### PR DESCRIPTION
Edit: retroactively created NDEV-2578 for this task

Here's a few minor changes to get it running locally.

Long term we may need to look at moving away from `pysha3` and `rusty_rlp` since they no longer install on newer Python.

To get `deploy_check` passing, I ran the following:

```
python -m venv .
source bin/activate
grep -vP '(pysha3|rusty_rlp)' requirements.txt > host-requirements.txt
pip3 install -r host-requirements.txt
rm -f host-requirements.txt
export IMAGE_NAME=neonlabsorg/proxy
export DOCKERHUB_ORG_NAME=neonlabsorg
python3 ./.github/workflows/deploy.py build_docker_image --proxy_tag local --neon_evm_tag latest
python3 ./.github/workflows/deploy.py deploy_check --proxy_tag local --neon_evm_tag latest --faucet_tag latest --skip_uniswap --skip_pull 2>&1 | tee test.log
```