### PR TITLE
NDEV2470 Evict old transactions from the mempool

### DIFF
--- a/proxy/common_neon/config.py
+++ b/proxy/common_neon/config.py
@@ -87,6 +87,7 @@ class Config(DBConfig):
 
         # Mempool limits
         self._mempool_capacity = self._env_num('MEMPOOL_CAPACITY', 4096, 10, 4096 * 1024)
+        self._mempool_eviction_timeout_sec = self._env_num('MEMPOOL_EVICTION_TIMEOUT_SEC', 60 * 60 * 3, 10, None)
         self._mempool_executor_limit_cnt = self._env_num('MEMPOOL_EXECUTOR_LIMIT_COUNT', 128, 4, 1024)
         self._mempool_cache_life_sec = self._env_num(
             'MEMPOOL_CACHE_LIFE_SEC',
@@ -392,6 +393,10 @@ class Config(DBConfig):
         return self._mempool_capacity
 
     @property
+    def mempool_eviction_timeout_sec(self) -> int:
+        return self._mempool_eviction_timeout_sec
+
+    @property
     def mempool_executor_limit_cnt(self) -> int:
         return self._mempool_executor_limit_cnt
 
@@ -637,6 +642,7 @@ class Config(DBConfig):
 
             # Mempool settings
             'MEMPOOL_CAPACITY': self.mempool_capacity,
+            'MEMPOOL_EVICTION_TIMEOUT_SEC': self.mempool_eviction_timeout_sec,
             'MEMPOOL_EXECUTOR_LIMIT_CNT': self.mempool_executor_limit_cnt,
             'MEMPOOL_CACHE_LIFE_SEC': self.mempool_cache_life_sec,
             'MEMPOOL_RESCHEDULE_TIME_SEC': self.mempool_reschedule_time_sec,

--- a/proxy/mempool/mempool_schedule.py
+++ b/proxy/mempool/mempool_schedule.py
@@ -289,6 +289,9 @@ class MPTxSchedule:
     def _add_tx_to_sender_pool(self, sender_pool: MPSenderTxPool, tx: MPTxRequest) -> None:
         LOG.debug(f'Add tx {tx.sig} to mempool with {self.tx_cnt} txs')
 
+        if self._sender_pool_heartbeat_queue.find(sender_pool) is not None:
+            self._sender_pool_heartbeat_queue.pop(sender_pool)
+        
         sender_pool.add_tx(tx)
         self._tx_dict.add_tx(tx)
 

--- a/proxy/mempool/mempool_schedule.py
+++ b/proxy/mempool/mempool_schedule.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 import enum
+import time
 
-from time import time
 from typing import List, Dict, Set, Optional, Tuple, Union, cast
 
 from ..common_neon.utils.neon_tx_info import NeonTxInfo
@@ -96,7 +96,7 @@ class MPSenderTxPool:
         self._state = self.State.Empty
         self._sender_address = sender_address
         self._gas_price = 0
-        self._heartbeat = int(time())
+        self._heartbeat = int(time.time())
         self._state_tx_cnt = 0
         self._processing_tx: Optional[MPTxRequest] = None
         self._tx_nonce_queue = SortedQueue[MPTxRequest, int, str](
@@ -152,7 +152,7 @@ class MPSenderTxPool:
     def add_tx(self, tx: MPTxRequest) -> None:
         assert self._state_tx_cnt <= tx.nonce, f'Tx {tx.sig} has nonce {tx.nonce} less than {self._state_tx_cnt}'
         self._tx_nonce_queue.add(tx)
-        self._heartbeat = int(time())
+        self._heartbeat = int(time.time())
 
     @property
     def top_tx(self) -> Optional[MPTxRequest]:
@@ -304,7 +304,7 @@ class MPTxSchedule:
         self._tx_dict.pop_tx(tx)
 
     def drop_expired_sender_pools(self, eviction_timeout_sec: int) -> None:
-        threshold = int(time()) - eviction_timeout_sec
+        threshold = int(time.time()) - eviction_timeout_sec
         LOG.debug(f'Try to drop sender pools with heartbeat below {threshold}')
 
         while True:

--- a/proxy/mempool/mempool_schedule.py
+++ b/proxy/mempool/mempool_schedule.py
@@ -322,7 +322,7 @@ class MPTxSchedule:
                 tx = sender_pool.top_tx
                 self._drop_tx_from_sender_pool(sender_pool, tx)
 
-            self._sync_sender_state(sender_pool, True)
+            self._sync_sender_state(sender_pool)
             
     def _find_sender_pool(self, sender_address: str) -> Optional[MPSenderTxPool]:
         return self._sender_pool_dict.get(sender_address, None)
@@ -357,11 +357,8 @@ class MPTxSchedule:
 
         sender_pool.set_state_tx_cnt(state_tx_cnt)
 
-    def _sync_sender_state(
-            self,
-            sender_pool: MPSenderTxPool,
-            skip_validation: bool=False) -> None:
-        if not skip_validation and sender_pool.has_valid_state():
+    def _sync_sender_state(self, sender_pool: MPSenderTxPool) -> None:
+        if sender_pool.has_valid_state():
             return
 
         old_state = sender_pool.state

--- a/proxy/mempool/mempool_schedule.py
+++ b/proxy/mempool/mempool_schedule.py
@@ -295,8 +295,8 @@ class MPTxSchedule:
         # the first tx in the sender pool
         if sender_pool.len_tx_nonce_queue == 1:
             self._sender_pool_dict[sender_pool.sender_address] = sender_pool
-
-        self._sender_pool_heartbeat_queue.try_add(sender_pool)
+        
+        self._sender_pool_heartbeat_queue.add(sender_pool)
 
     def _drop_tx_from_sender_pool(self, sender_pool: MPSenderTxPool, tx: MPTxRequest) -> None:
         LOG.debug(f'Drop tx {tx.sig} from pool {sender_pool.sender_address}')
@@ -381,7 +381,7 @@ class MPTxSchedule:
         new_state = sender_pool.sync_state()
         if new_state == sender_pool.State.Empty:
             self._sender_pool_dict.pop(sender_pool.sender_address)
-            self._sender_pool_heartbeat_queue.try_pop(sender_pool)
+            self._sender_pool_heartbeat_queue.pop(sender_pool)
             LOG.debug(f'Done sender {self._chain_id, sender_pool.sender_address}')
         elif new_state == sender_pool.State.Suspended:
             self._suspended_sender_set.add(NeonAddress.from_raw(sender_pool.sender_address, self._chain_id))

--- a/proxy/mempool/mempool_schedule.py
+++ b/proxy/mempool/mempool_schedule.py
@@ -310,11 +310,7 @@ class MPTxSchedule:
         while not self._sender_pool_heartbeat_queue.is_empty():
             sender_pool = self._sender_pool_heartbeat_queue[self._top_index]
 
-            if any([
-                sender_pool is None,
-                threshold < sender_pool.heartbeat,
-                sender_pool.is_processing()
-            ]):
+            if threshold < sender_pool.heartbeat or sender_pool.is_processing():
                 break
 
             LOG.debug('Droping sender pool {} with heartbeat {}'.format(
@@ -324,10 +320,6 @@ class MPTxSchedule:
 
             while not sender_pool.is_empty():
                 tx = sender_pool.top_tx
-
-                if tx is None:
-                    break
-
                 self._drop_tx_from_sender_pool(sender_pool, tx)
 
             self._sync_sender_state(sender_pool, True)

--- a/proxy/mempool/mempool_schedule.py
+++ b/proxy/mempool/mempool_schedule.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import enum
 
+from time import time
 from typing import List, Dict, Set, Optional, Tuple, Union, cast
 
 from ..common_neon.utils.neon_tx_info import NeonTxInfo
@@ -95,6 +96,7 @@ class MPSenderTxPool:
         self._state = self.State.Empty
         self._sender_address = sender_address
         self._gas_price = 0
+        self._heartbeat = int(time())
         self._state_tx_cnt = 0
         self._processing_tx: Optional[MPTxRequest] = None
         self._tx_nonce_queue = SortedQueue[MPTxRequest, int, str](
@@ -150,6 +152,7 @@ class MPSenderTxPool:
     def add_tx(self, tx: MPTxRequest) -> None:
         assert self._state_tx_cnt <= tx.nonce, f'Tx {tx.sig} has nonce {tx.nonce} less than {self._state_tx_cnt}'
         self._tx_nonce_queue.add(tx)
+        self._heartbeat = int(time())
 
     @property
     def top_tx(self) -> Optional[MPTxRequest]:
@@ -191,6 +194,10 @@ class MPSenderTxPool:
 
     def set_state_tx_cnt(self, value: int) -> None:
         self._state_tx_cnt = value
+
+    @property
+    def heartbeat(self) -> int:
+        return self._heartbeat
 
     def _validate_processing_tx(self, tx: MPTxRequest) -> None:
         assert not self.is_empty(), f'no transactions in {self.sender_address} pool'

--- a/proxy/mempool/sorted_queue.py
+++ b/proxy/mempool/sorted_queue.py
@@ -52,10 +52,6 @@ class SortedQueue(Generic[SortedQueueItem, SortedQueueLtKey, SortedQueueEqKey]):
         assert self.find_from_pos(pos, item) is None, 'item is already in the queue'
         self._impl.queue.insert(pos, item)
 
-    def try_add(self, item: SortedQueueItem) -> None:
-        if self.find(item) is None:
-            self.add(item)
-
     def find(self, item: SortedQueueItem) -> Optional[int]:
         start_pos = self._impl.bisect_left(item)
         return self.find_from_pos(start_pos, item)
@@ -75,14 +71,6 @@ class SortedQueue(Generic[SortedQueueItem, SortedQueueLtKey, SortedQueueEqKey]):
         assert index is not None, 'item is absent in the queue'
 
         return self._impl.queue.pop(index)
-
-    def try_pop(self, item: SortedQueueItem) -> Optional[SortedQueueItem]:
-        index = self.find(item)
-
-        if index is None:
-            return None
-
-        return self.pop(index)
 
     def clear(self) -> None:
         self._impl.queue.clear()

--- a/proxy/mempool/sorted_queue.py
+++ b/proxy/mempool/sorted_queue.py
@@ -74,3 +74,6 @@ class SortedQueue(Generic[SortedQueueItem, SortedQueueLtKey, SortedQueueEqKey]):
 
     def clear(self) -> None:
         self._impl.queue.clear()
+
+    def is_empty(self) -> bool:
+        return not len(self._impl.queue)

--- a/proxy/mempool/sorted_queue.py
+++ b/proxy/mempool/sorted_queue.py
@@ -52,6 +52,10 @@ class SortedQueue(Generic[SortedQueueItem, SortedQueueLtKey, SortedQueueEqKey]):
         assert self.find_from_pos(pos, item) is None, 'item is already in the queue'
         self._impl.queue.insert(pos, item)
 
+    def try_add(self, item: SortedQueueItem) -> None:
+        if self.find(item) is None:
+            self.add(item)
+
     def find(self, item: SortedQueueItem) -> Optional[int]:
         start_pos = self._impl.bisect_left(item)
         return self.find_from_pos(start_pos, item)
@@ -71,6 +75,14 @@ class SortedQueue(Generic[SortedQueueItem, SortedQueueLtKey, SortedQueueEqKey]):
         assert index is not None, 'item is absent in the queue'
 
         return self._impl.queue.pop(index)
+
+    def try_pop(self, item: SortedQueueItem) -> Optional[SortedQueueItem]:
+        index = self.find(item)
+
+        if index is None:
+            return None
+
+        return self.pop(index)
 
     def clear(self) -> None:
         self._impl.queue.clear()


### PR DESCRIPTION
Moving here because PR https://github.com/neonlabsorg/proxy-model.py/pull/245 had a "/" in the branch name which broke CI.