### PR TITLE
SLA-34 mempool: Prevent garbage collection of eviction async task

### DIFF
--- a/proxy/mempool/mempool.py
+++ b/proxy/mempool/mempool.py
@@ -82,7 +82,7 @@ class MemPool(IEVMConfigUser, IGasPriceUser, IMPExecutorMngUser):
         self._free_alt_queue_task_loop: Optional[MPFreeALTQueueTaskLoop] = None
 
     def start(self) -> None:
-        asyncio.get_event_loop().create_task(self._process_eviction_loop()),
+        self._async_task_list.append(asyncio.get_event_loop().create_task(self._process_eviction_loop()))
         asyncio.get_event_loop().run_until_complete(self._executor_mng.set_executor_cnt(1))
         self._async_task_list.append(MPEVMConfigTaskLoop(self._executor_mng, self))
 


### PR DESCRIPTION
Thinking the current issue could be an `asyncio` problem, I had a look at the documentation again:

https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task

> Important Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done. For reliable “fire-and-forget” background tasks, gather them in a collection

This may not be the fix, but it's something that needs to be cleaned up.