### PR TITLE
NDEV-2604 mempool: Trigger more NonceTooHigh rejection errors for test

### DIFF
--- a/proxy/testing/test_mempool.py
+++ b/proxy/testing/test_mempool.py
@@ -598,11 +598,10 @@ class TestMPSchedule(unittest.TestCase):
             account_nonces.append(0)
 
             for _ in range(0, reqs_per_acc):
-                if random.choice([True, False]):  # 50% chance of having a nonce gap
+                # Once we are over the limit, there is a 50% chance of having a nonce gap
+                if len(req_list) > mp_schedule_capacity_limit and random.choice([True, False]):
                     nonce = account_nonces[acc_idx] + randint(2, 100)
-
-                    if len(req_list) > mp_schedule_capacity_limit:
-                        expected_nonce_gap_error_count += 1
+                    expected_nonce_gap_error_count += 1
                 else:
                     nonce = account_nonces[acc_idx]
                     account_nonces[acc_idx] += 1
@@ -619,6 +618,7 @@ class TestMPSchedule(unittest.TestCase):
 
         nonce_too_high_error_count = 0
         underprice_error_count = 0
+        success_count = 0
 
         for req in req_list:
             result = schedule.add_tx(req)
@@ -627,13 +627,16 @@ class TestMPSchedule(unittest.TestCase):
                 nonce_too_high_error_count += 1
             elif result.code == MPTxSendResultCode.Underprice:
                 underprice_error_count += 1
-            elif result.code != MPTxSendResultCode.Success:
+            elif result.code == MPTxSendResultCode.Success:
+                success_count += 1
+            else:
                 self.fail(f"Unexpected result code: {result.code}")
 
         self.assertGreater(expected_nonce_gap_error_count, 0)
         self.assertGreater(nonce_too_high_error_count, 0)
         self.assertGreater(underprice_error_count, 0)
-        self.assertGreater(nonce_too_high_error_count + underprice_error_count, mp_schedule_capacity_limit)
+        self.assertGreater(success_count, 0)
+        self.assertEqual(nonce_too_high_error_count + underprice_error_count + success_count, len(req_list))
         self.assertEqual(mp_schedule_capacity, schedule.tx_cnt)
 
     def test_tx_lifecycle(self):


### PR DESCRIPTION
Because `test_capacity_oversized_with_nonce_rejection()` relies on randomness, sometimes there are not enough `NonceTooHigh` errors which triggers the `assert`. This change increases the number of `NonceTooHigh` errors that are generated in the test so the asserts are practically unlikely.