### PR TITLE
NDEV-2806 Overrides solana accounts

### DIFF
--- a/proxy/common_neon/data.py
+++ b/proxy/common_neon/data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, Any, List, Optional, NewType
 
 from .solana_alt import ALTAddress
-from .solana_tx import SolTx, SolPubKey
+from .solana_tx import SolTx, SolPubKey, SolAccountData
 from .utils import str_fmt_object, cached_property, cached_method
 
 
@@ -17,6 +17,7 @@ class NeonEmulatorExitStatus:
     def to_type(value: str) -> Type:
         return NeonEmulatorExitStatus.Type(value.lower())
 
+SolanaOverrides = Dict[SolPubKey, Optional[SolAccountData]]
 
 class NeonEmulatorResult:
     def __init__(self, res_dict: Optional[Dict[str, Any]] = None):

--- a/proxy/common_neon/erc20_wrapper.py
+++ b/proxy/common_neon/erc20_wrapper.py
@@ -8,18 +8,15 @@ from spl.token.client import Token
 
 from solana.rpc.types import TxOpts
 from solana.rpc.commitment import Confirmed
-from solana.rpc.api import Client
 
 from solcx import install_solc, compile_source
 
-from .layouts import AccountInfo
 from .solana_tx import SolAccountMeta, SolAccount, SolPubKey
+from .data import SolanaOverrides
 from .constants import ACCOUNT_SEED_VERSION, EVM_PROGRAM_ID
 from .utils.eth_proto import NeonTx
 from .neon_instruction import NeonIxBuilder
 from .web3 import NeonWeb3, ChecksumAddress, EmulateParams
-from ..common_neon.solana_tx import SolPubKey, SolAccountData
-from ..common_neon.data import SolanaOverrides
 
 install_solc(version='0.7.6')
 
@@ -161,9 +158,9 @@ class ERC20Wrapper:
         ).build_transaction(
             {'nonce': nonce, 'gasPrice': 0, 'from': signer_acct.address, 'gas': 0}
         )
+        
         emulate_params = EmulateParams(solana_overrides=overrides) if overrides else None
         claim_tx.update({'gas': self.proxy.neon.neon_estimateGas(claim_tx, emulate_params)})
-        print(f"Claim_tx: {claim_tx}")
         return self._create_builder(claim_tx, owner, signer_acct, emulate_params=emulate_params)
 
     def _create_builder(self, tx, owner: SolPubKey, signer_acct: NeonAccount, emulate_params: Optional[EmulateParams] = None):
@@ -171,8 +168,7 @@ class ERC20Wrapper:
         pda_acct = self.proxy.neon.get_neon_account(signer_acct.address).solanaAddress
 
         neon_tx = bytearray.fromhex(tx.rawTransaction.hex()[2:])
-        emulating_result = self.proxy.neon.neon_emulate(neon_tx, emulate_params)   # TODO: Add overrides
-        print(f"Emulating result: {emulating_result}")
+        emulating_result = self.proxy.neon.neon_emulate(neon_tx, emulate_params)
 
         neon_account_dict = dict()
         for account in emulating_result['solana_accounts']:

--- a/proxy/common_neon/solana_tx.py
+++ b/proxy/common_neon/solana_tx.py
@@ -4,6 +4,7 @@ from typing import Sequence, Optional, Union, Dict, Any, Set, List, NewType
 
 import abc
 
+import solders.account
 import solders.hash
 import solders.keypair
 import solders.pubkey
@@ -16,6 +17,7 @@ from .eth_commit import EthCommit
 
 
 SolTxIx = solders.instruction.Instruction
+SolAccountData = solders.account.Account
 SolAccountMeta = solders.instruction.AccountMeta
 SolBlockHash = solders.hash.Hash
 SolAccount = solders.keypair.Keypair

--- a/proxy/common_neon/web3.py
+++ b/proxy/common_neon/web3.py
@@ -49,7 +49,11 @@ class EmulateParams:
 class Neon(Module):
     _neon_emulate = RPCEndpoint('neon_emulate')
 
-    def _neon_emulate_munger(self, tx: bytearray, params: Optional[EmulateParams]) -> Tuple[str, Optional[Dict[str,Any]]]:
+    def _neon_emulate_munger(
+        self,
+        tx: bytearray,
+        params: Optional[EmulateParams] = None
+    ) -> Tuple[str, Optional[Dict[str,Any]]]:
         if params is None:
             return (bytes(tx).hex(),)
         else:
@@ -65,9 +69,14 @@ class Neon(Module):
     _neon_estimateGas = RPCEndpoint('neon_estimateGas')
 
     def _neon_estimateGas_munger(
-        self, transaction: TxParams, params: Optional[EmulateParams]
+        self,
+        transaction: TxParams,
+        params: Optional[EmulateParams] = None
     ) -> Tuple[TxParams, Optional[Dict[str,Any]]]:
-        return transaction, params.to_dict()
+        if params is None:
+            return transaction
+        else:
+            return transaction, params.to_dict()
         
     neon_estimateGas: Method[
         Callable[[TxParams, Optional[EmulateParams]], int]

--- a/proxy/common_neon/web3.py
+++ b/proxy/common_neon/web3.py
@@ -4,9 +4,8 @@ from web3 import Web3
 from web3.module import Module
 from web3.method import Method, default_root_munger
 from web3.providers.base import BaseProvider
-from typing import Optional, Tuple, Callable, Union, Dict, List, Any
+from typing import Optional, Tuple, Callable, Union, Dict, Any
 from web3.types import RPCEndpoint, TxParams, HexBytes, ChecksumAddress, Address, BlockIdentifier, LatestBlockParam
-from ..common_neon.solana_tx import SolAccountData, SolPubKey
 from ..common_neon.data import SolanaOverrides
 
 

--- a/proxy/neon_core_api/neon_core_api_client.py
+++ b/proxy/neon_core_api/neon_core_api_client.py
@@ -171,7 +171,6 @@ class NeonCoreApiClient(NeonClientBase):
             solana_overrides=solana_overrides
         )
         request = self._add_block(request, block)
-        LOG.debug(f"emulate: {request}")
         response = self._call(_MethodName.emulate, request)
         self._check_emulated_error(response)
 

--- a/proxy/neon_core_api/neon_core_api_client.py
+++ b/proxy/neon_core_api/neon_core_api_client.py
@@ -15,7 +15,7 @@ from ..common_neon.config import Config
 from ..common_neon.data import NeonEmulatorResult, NeonEmulatorExitStatus
 from ..common_neon.errors import EthereumError
 from ..common_neon.solana_block import SolBlockInfo
-from ..common_neon.solana_tx import SolCommit, SolPubKey
+from ..common_neon.solana_tx import SolCommit, SolPubKey, SolAccountData
 from ..common_neon.utils.eth_proto import NeonTx
 from ..common_neon.utils.utils import cached_property
 from ..common_neon.evm_config import EVMConfig
@@ -125,7 +125,8 @@ class NeonCoreApiClient(NeonClientBase):
         value: Optional[Union[str, int]],
         gas_limit: Optional[str] = None,
         block: Optional[SolBlockInfo] = None,
-        check_result=False
+        check_result=False,
+        overrides: Dict[SolPubKey,SolAccountData] = [],
     ) -> NeonEmulatorResult:
         if not sender:
             sender = '0x0000000000000000000000000000000000000000'
@@ -167,8 +168,10 @@ class NeonCoreApiClient(NeonClientBase):
                 # 'gas_limit': gas_limit,
                 # 'access_list': None
             },
+            solana_overrides=overrides,
         )
         request = self._add_block(request, block)
+        LOG.debug(f"emulate: {request}")
         response = self._call(_MethodName.emulate, request)
         self._check_emulated_error(response)
 

--- a/proxy/neon_rpc_api_model/estimate.py
+++ b/proxy/neon_rpc_api_model/estimate.py
@@ -8,7 +8,7 @@ from ..common_neon.data import NeonEmulatorResult
 from ..common_neon.utils.eth_proto import NeonTx
 from ..common_neon.neon_instruction import NeonIxBuilder
 from ..common_neon.solana_alt_limit import ALTLimit
-from ..common_neon.solana_tx import SolAccount, SolPubKey, SolAccountMeta, SolBlockHash, SolTxSizeError
+from ..common_neon.solana_tx import SolAccountData, SolAccount, SolPubKey, SolAccountMeta, SolBlockHash, SolTxSizeError
 from ..common_neon.solana_tx_legacy import SolLegacyTx
 from ..common_neon.solana_block import SolBlockInfo
 from ..common_neon.address import NeonAddress
@@ -102,7 +102,7 @@ class GasEstimate:
     def _execute(self, block: SolBlockInfo) -> None:
         self._emulator_result = self._core_api_client.emulate(
             self._contract, self._sender, self._def_chain_id, self._data, self._value,
-            gas_limit=self._gas, block=block, check_result=True,
+            gas_limit=self._gas, block=block, check_result=True, overrides=self._overrides,
         )
 
     def _tx_size_cost(self) -> int:
@@ -179,7 +179,8 @@ class GasEstimate:
         for account in self._emulator_result.solana_account_list:
             self._account_list.append(SolAccountMeta(SolPubKey.from_string(account['pubkey']), False, True))
 
-    def estimate(self, request: Dict[str, Any], block: SolBlockInfo):
+    def estimate(self, request: Dict[str, Any], block: SolBlockInfo, overrides: Dict[SolPubKey,SolAccountData]=[]):
+        self._overrides = overrides
         self._get_request_param(request)
         self._execute(block)
         self._build_account_list()

--- a/proxy/neon_rpc_api_model/estimate.py
+++ b/proxy/neon_rpc_api_model/estimate.py
@@ -8,7 +8,7 @@ from ..common_neon.data import NeonEmulatorResult, SolanaOverrides
 from ..common_neon.utils.eth_proto import NeonTx
 from ..common_neon.neon_instruction import NeonIxBuilder
 from ..common_neon.solana_alt_limit import ALTLimit
-from ..common_neon.solana_tx import SolAccountData, SolAccount, SolPubKey, SolAccountMeta, SolBlockHash, SolTxSizeError
+from ..common_neon.solana_tx import SolAccount, SolPubKey, SolAccountMeta, SolBlockHash, SolTxSizeError
 from ..common_neon.solana_tx_legacy import SolLegacyTx
 from ..common_neon.solana_block import SolBlockInfo
 from ..common_neon.address import NeonAddress
@@ -99,7 +99,7 @@ class GasEstimate:
         self._gas: Optional[str] = _get_hex('gas') or hex(self._u256_max)
         self._gas_price: Optional[str] = _get_hex('gasPrice')
 
-    def _execute(self, block: SolBlockInfo, solana_overrides: Optional[SolanaOverrides]=None) -> None:
+    def _execute(self, block: SolBlockInfo, solana_overrides: Optional[SolanaOverrides] = None) -> None:
         self._emulator_result = self._core_api_client.emulate(
             self._contract, self._sender, self._def_chain_id, self._data, self._value,
             gas_limit=self._gas, block=block, check_result=True, solana_overrides=solana_overrides,
@@ -179,7 +179,7 @@ class GasEstimate:
         for account in self._emulator_result.solana_account_list:
             self._account_list.append(SolAccountMeta(SolPubKey.from_string(account['pubkey']), False, True))
 
-    def estimate(self, request: Dict[str, Any], block: SolBlockInfo, solana_overrides: Optional[SolanaOverrides]=None):
+    def estimate(self, request: Dict[str, Any], block: SolBlockInfo, solana_overrides: Optional[SolanaOverrides] = None):
         self._get_request_param(request)
         self._execute(block, solana_overrides)
         self._build_account_list()

--- a/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
+++ b/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
@@ -31,7 +31,7 @@ from ..common_neon.neon_tx_result_info import NeonTxResultInfo
 from ..common_neon.solana_block import SolBlockInfo
 from ..common_neon.solana_interactor import SolInteractor
 from ..common_neon.solana_neon_tx_receipt import SolNeonIxReceiptInfo, SolAltIxInfo
-from ..common_neon.solana_tx import SolCommit
+from ..common_neon.solana_tx import SolCommit, SolPubKey, SolAccountData
 from ..common_neon.utils import NeonTxInfo
 from ..common_neon.utils.eth_proto import NeonTx
 from ..common_neon.evm_log_decoder import NeonLogTxEvent
@@ -352,7 +352,7 @@ class NeonRpcApiWorker:
 
         return self._gas_tank.has_gas_less_tx_permit(addr)
 
-    def eth_estimateGas(self, param: Dict[str, Any], tag: Union[str, int, dict] = 'latest') -> str:
+    def neon_estimateGas(self, param: Dict[str, Any], tag: Union[str, int, dict] = 'latest', overrides: Dict[SolPubKey, SolAccountData]=[]) -> str:
         block = self._process_block_tag(tag)
 
         if not isinstance(param, dict):
@@ -364,13 +364,16 @@ class NeonRpcApiWorker:
 
         try:
             calculator = GasEstimate(self._config, self._core_api_client, self._chain_id)
-            return hex(calculator.estimate(param, block))
+            return hex(calculator.estimate(param, block, overrides))
 
         except EthereumError:
             raise
         except BaseException as exc:
             LOG.debug(f"Exception on eth_estimateGas: {str(exc)}")
             raise
+
+    def eth_estimateGas(self, param: Dict[str, Any], tag: Union[str, int, dict] = 'latest') -> str:
+        return self.neon_estimateGas(param, tag, [])
 
     def __repr__(self):
         return str(self.__dict__)

--- a/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
+++ b/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
@@ -31,7 +31,7 @@ from ..common_neon.neon_tx_result_info import NeonTxResultInfo
 from ..common_neon.solana_block import SolBlockInfo
 from ..common_neon.solana_interactor import SolInteractor
 from ..common_neon.solana_neon_tx_receipt import SolNeonIxReceiptInfo, SolAltIxInfo
-from ..common_neon.solana_tx import SolCommit, SolPubKey, SolAccountData
+from ..common_neon.solana_tx import SolCommit
 from ..common_neon.utils import NeonTxInfo
 from ..common_neon.utils.eth_proto import NeonTx
 from ..common_neon.evm_log_decoder import NeonLogTxEvent

--- a/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
+++ b/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
@@ -352,7 +352,11 @@ class NeonRpcApiWorker:
 
         return self._gas_tank.has_gas_less_tx_permit(addr)
 
-    def neon_estimateGas(self, param: Dict[str, Any], tag: Union[str, int, dict] = 'latest', overrides: Dict[SolPubKey, SolAccountData]=[]) -> str:
+    def neon_estimateGas(self, param: Dict[str, Any], emulate_params: Optional[Dict[str,Any]]) -> str:
+        if emulate_params is None:
+            emulate_params = dict()
+
+        tag = emulate_params.get('tag') or 'latest'
         block = self._process_block_tag(tag)
 
         if not isinstance(param, dict):
@@ -364,7 +368,7 @@ class NeonRpcApiWorker:
 
         try:
             calculator = GasEstimate(self._config, self._core_api_client, self._chain_id)
-            return hex(calculator.estimate(param, block, overrides))
+            return hex(calculator.estimate(param, block, emulate_params.get('solana_overrides')))
 
         except EthereumError:
             raise
@@ -373,7 +377,7 @@ class NeonRpcApiWorker:
             raise
 
     def eth_estimateGas(self, param: Dict[str, Any], tag: Union[str, int, dict] = 'latest') -> str:
-        return self.neon_estimateGas(param, tag, [])
+        return self.neon_estimateGas(param, dict(tag=tag))
 
     def __repr__(self):
         return str(self.__dict__)
@@ -1361,13 +1365,14 @@ class NeonRpcApiWorker:
                 return sol_sig_list
         return sol_sig_list
 
-    def neon_emulate(self, raw_signed_tx: str):
+    def neon_emulate(self, raw_signed_tx: str, emulate_params: Optional[Dict[str,Any]]=None):
         """Executes emulator with given transaction"""
         LOG.debug(f'Call neon_emulate: {raw_signed_tx}')
 
         neon_tx = NeonTx.from_string(bytearray.fromhex(raw_signed_tx))
         chain_id = neon_tx.chain_id or self._chain_id
-        emulator_result = self._core_api_client.emulate_neon_tx(neon_tx, chain_id)
+        solana_overrides = emulate_params.get('solana_overrides') if emulate_params else None
+        emulator_result = self._core_api_client.emulate_neon_tx(neon_tx, chain_id, solana_overrides)
         return emulator_result.full_dict
 
     def neon_finalizedBlockNumber(self) -> str:

--- a/proxy/testing/test_gas_tank_integration.py
+++ b/proxy/testing/test_gas_tank_integration.py
@@ -8,7 +8,6 @@ from typing import Dict, Any
 from solana.rpc.api import Client as RPCSolClient
 from solana.rpc.commitment import Confirmed as RPCSolConfirmed
 from solders.system_program import ID as SYS_PROGRAM_ID
-from solders.account import Account as SolAccountData
 
 from spl.token.client import Token as SplToken
 from spl.token._layouts import ACCOUNT_LAYOUT
@@ -16,7 +15,7 @@ from spl.token.constants import TOKEN_PROGRAM_ID
 import spl.token.instructions as SplTokenIxs
 
 from proxy.common_neon.metaplex import create_metadata_instruction_data, create_metadata_instruction
-from proxy.common_neon.solana_tx import SolAccountMeta, SolTxIx, SolAccount, SolPubKey
+from proxy.common_neon.solana_tx import SolAccountMeta, SolTxIx, SolAccount, SolPubKey, SolAccountData
 from proxy.common_neon.neon_instruction import NeonIxBuilder
 from proxy.common_neon.erc20_wrapper import ERC20Wrapper
 from proxy.common_neon.config import Config
@@ -45,6 +44,7 @@ class TestGasTankIntegration(TestCase):
     mint_authority: SolAccount
     token: SplToken
     erc20_for_spl: ERC20Wrapper
+    solana: SolClient
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
1. Introduced `SolanaOverrides` as a `Dict[SolPubKey, SolAccountData]`
2. Introduced `EmulateParams` structure with `tag: BlockIdentifier, solana_overrides: SolanaOverrides`
3. Implemented `neon_estimateGas` method which estimates gas using the optional `EmulateParams`
4. Added the optional `EmulateParams` parameter to the `neon_emulate` method

Example of `EmulateParams` with overrides Solana accounts (`data` is encoded in hex-form):
```JSON
{
    "solana_overrides": {
        "7th2NmSqT1ifXPYFSBD9iMPZJ1HF7NzFHpGorWvPX4f4": {
            "lamports": 2039280,
            "data": "d74cf5677504c70a053492feb106aa4769156982692033d875e0cad28056dd98e98950ba06a9ad4f9b0db43932f121f19607effe90ce14f2c3344218c4abfb280010a5d4e800000001000000e1fa382f3a16a6ccbba65a76e725a6a21537bc6bc91450128acdfefd08f3f2700100000000000000000000000040e2010000000000000000000000000000000000000000000000000000000000000000000000000000000000",
            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
            "executable": false,
            "rent_epoch": 0
        }
    }
}
```