### PR TITLE
Chore: Adding convenience scripts for local development

### DIFF
--- a/devel/containers-down.sh
+++ b/devel/containers-down.sh
@@ -11,8 +11,14 @@ export REVISION=${REVISION:-$PROXY_REVISION}
 export VIRTUAL_ENV=${VIRTUAL_ENV:-}
 
 BINDIR="$(dirname $BASH_SOURCE)"
+COMPOSE_OVERRIDES=""
+
+if [ "$PROXY_REVISION" == "local" ]; then
+    COMPOSE_OVERRIDES="-f $BINDIR/../docker-compose/docker-compose-local-development.yml"
+fi
 
 docker-compose \
     -f "$BINDIR/../docker-compose/docker-compose-ci.yml" \
+    $COMPOSE_OVERRIDES \
     -p "$PROJECT_NAME" \
-    down
+    down -v

--- a/devel/containers-down.sh
+++ b/devel/containers-down.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -xeou pipefail
+
+export DOCKERHUB_ORG_NAME=${DOCKERHUB_ORG_NAME:-neonlabsorg}
+export FAUCET_COMMIT=${FAUCET_COMMIT:-latest}
+export NEON_EVM_COMMIT=${NEON_EVM_COMMIT:-latest}
+export PROXY_REVISION=${PROXY_REVISION:-local}
+export PROJECT_NAME=${PROJECT_NAME:-local}
+export REVISION=${REVISION:-$PROXY_REVISION}
+export VIRTUAL_ENV=${VIRTUAL_ENV:-}
+
+BINDIR="$(dirname $BASH_SOURCE)"
+
+docker-compose \
+    -f "$BINDIR/../docker-compose/docker-compose-ci.yml" \
+    -p "$PROJECT_NAME" \
+    down

--- a/devel/containers-up.sh
+++ b/devel/containers-up.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -xeou pipefail
+
+export CONTRACTS_BRANCH=${CONTRACTS_BRANCH:-develop}
+export DOCKERHUB_ORG_NAME=${DOCKERHUB_ORG_NAME:-neonlabsorg}
+export FAUCET_COMMIT=${FAUCET_COMMIT:-latest}
+export NEON_EVM_COMMIT=${NEON_EVM_COMMIT:-latest}
+export PROXY_REVISION=${PROXY_REVISION:-local}
+export PROJECT_NAME=${PROJECT_NAME:-local}
+export REVISION=${REVISION:-$PROXY_REVISION}
+export VIRTUAL_ENV=${VIRTUAL_ENV:-}
+
+BINDIR="$(dirname $BASH_SOURCE)"
+COMPOSE_OVERRIDES=""
+CONTRACTS_URL="https://github.com/neonlabsorg/neon-evm/archive/refs/heads/$CONTRACTS_BRANCH.tar.gz"
+
+if  [ -z "$VIRTUAL_ENV" ]; then
+    python3 -m venv "$BINDIR/../.venv"
+    source "$BINDIR/../.venv/bin/activate"
+    pip install -r requirements.txt
+fi
+
+if [ "$NEON_EVM_COMMIT" != "local" ]; then
+    docker pull "neonlabsorg/evm_loader:$NEON_EVM_COMMIT"
+fi
+
+if [ "$PROXY_REVISION" == "local" ]; then
+    COMPOSE_OVERRIDES="-f $BINDIR/../docker-compose/docker-compose-local-development.yml"
+
+    if [ ! -d "$BINDIR/../contracts" ]; then
+        mkdir -p "$BINDIR/../contracts"
+        curl -L $CONTRACTS_URL | tar -xz -C "$BINDIR/../contracts"
+        mv $BINDIR/../contracts/neon-evm-develop/solidity/* "$BINDIR/../contracts"
+        rm -rf "$BINDIR/../contracts/neon-evm-develop"
+    fi
+
+    docker build \
+        -t "$DOCKERHUB_ORG_NAME/proxy:$PROXY_REVISION" \
+        -f "$BINDIR/../Dockerfile" \
+        --build-arg "NEON_EVM_COMMIT=$NEON_EVM_COMMIT" \
+        --build-arg "DOCKERHUB_ORG_NAME=$DOCKERHUB_ORG_NAME" \
+        --build-arg "PROXY_REVISION=$PROXY_REVISION" \
+        "$BINDIR/.."
+fi
+
+ docker-compose \
+    -f "$BINDIR/../docker-compose/docker-compose-ci.yml" \
+    $COMPOSE_OVERRIDES \
+    -p "$PROJECT_NAME" \
+    up

--- a/devel/proxy-down.sh
+++ b/devel/proxy-down.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -xeou pipefail
+
+export DOCKERHUB_ORG_NAME=${DOCKERHUB_ORG_NAME:-neonlabsorg}
+export FAUCET_COMMIT=${FAUCET_COMMIT:-latest}
+export NEON_EVM_COMMIT=${NEON_EVM_COMMIT:-latest}
+export PROXY_REVISION=${PROXY_REVISION:-local}
+export PROJECT_NAME=${PROJECT_NAME:-local}
+export REVISION=${REVISION:-$PROXY_REVISION}
+
+BINDIR="$(dirname $BASH_SOURCE)"
+
+if [ -f /.dockerenv ]; then
+    if [ ! -f /usr/bin/pkill ]; then
+        # one-time install, so we can kill without dangling children
+        apt-get update
+        apt-get install -y psmisc
+    fi
+
+    pkill -f 'python3\ \-m\ proxy|bash.*run(-test)?-proxy.sh'
+else
+    CONTAINERS_RUNNING=$(docker-compose ls -q --filter name=${PROJECT_NAME})
+
+    if [ "$CONTAINERS_RUNNING" ]; then
+        docker exec -it "${PROJECT_NAME}-proxy-1" /opt/devel/proxy-down.sh
+    fi
+fi

--- a/devel/proxy-shell.sh
+++ b/devel/proxy-shell.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -xeou pipefail
+
+export DOCKERHUB_ORG_NAME=${DOCKERHUB_ORG_NAME:-neonlabsorg}
+export FAUCET_COMMIT=${FAUCET_COMMIT:-latest}
+export NEON_EVM_COMMIT=${NEON_EVM_COMMIT:-latest}
+export PROXY_REVISION=${PROXY_REVISION:-local}
+export PROJECT_NAME=${PROJECT_NAME:-local}
+export REVISION=${REVISION:-$PROXY_REVISION}
+
+if [ -f /.dockerenv ]; then
+    set +x
+
+    echo "error: cannot run this script inside a container"
+    exit 1
+else
+    PROXY_CONTAINER=$(docker ps -q -f name=${PROJECT_NAME}-proxy-1)
+
+    if [ -z "$PROXY_CONTAINER" ]; then
+        set +x
+
+        echo "error: proxy container not running"
+        echo
+        echo "To start the proxy container:"
+        echo
+        echo "  ./devel/proxy-up.sh"
+        echo
+        exit 1
+    else
+        docker exec -it "${PROJECT_NAME}-proxy-1" /bin/bash
+    fi
+fi

--- a/devel/proxy-test.sh
+++ b/devel/proxy-test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Note: This script runs the tests within an running proxy
+#       container that has a running proxy process, but it does
+#       not start the proxy container itself and does not start the
+#       proxy process either.
+#
+#       To start the proxy container and process, use `./devel/proxy-up.sh`.
+#
+
+set -euo pipefail
+
+export DOCKERHUB_ORG_NAME=${DOCKERHUB_ORG_NAME:-neonlabsorg}
+export FAUCET_COMMIT=${FAUCET_COMMIT:-latest}
+export NEON_EVM_COMMIT=${NEON_EVM_COMMIT:-latest}
+export PROXY_REVISION=${PROXY_REVISION:-local}
+export PROJECT_NAME=${PROJECT_NAME:-local}
+export REVISION=${REVISION:-$PROXY_REVISION}
+
+BINDIR="$(dirname $BASH_SOURCE)"
+
+if [ -f /.dockerenv ]; then
+    /opt/proxy/deploy-test.sh
+else
+    PROXY_CONTAINER=$(docker ps -q -f name=${PROJECT_NAME}-proxy-1)
+
+    if [ -z "$PROXY_CONTAINER" ]; then
+        set +x
+
+        echo "error: proxy container not running"
+        echo
+        echo "To start the proxy container:"
+        echo
+        echo "  ./devel/proxy-up.sh"
+        echo
+        exit 1
+    else
+        docker exec -it "${PROJECT_NAME}-proxy-1" /opt/proxy/deploy-test.sh
+    fi
+fi

--- a/devel/proxy-up.sh
+++ b/devel/proxy-up.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -xeou pipefail
+
+export DOCKERHUB_ORG_NAME=${DOCKERHUB_ORG_NAME:-neonlabsorg}
+export FAUCET_COMMIT=${FAUCET_COMMIT:-latest}
+export NEON_EVM_COMMIT=${NEON_EVM_COMMIT:-latest}
+export PROXY_REVISION=${PROXY_REVISION:-local}
+export PROJECT_NAME=${PROJECT_NAME:-local}
+export REVISION=${REVISION:-$PROXY_REVISION}
+
+if [ -f /.dockerenv ]; then
+    # temporary hack to fix stale plugin cache on restart
+    rm -Rf /opt/proxy/plugin/__pycache__/*
+
+    /opt/proxy/run-test-proxy.sh
+else
+    CONTAINERS_RUNNING=$(docker-compose ls -q --filter name=${PROJECT_NAME})
+
+    if [ -z "$CONTAINERS_RUNNING" ]; then
+        set +x
+
+        echo "error: containers not running"
+        echo
+        echo "To start the containers:"
+        echo
+        echo "  ./devel/containers-up.sh"
+        echo
+        exit 1
+    else
+        docker exec -it "${PROJECT_NAME}-proxy-1" /opt/devel/proxy-up.sh
+    fi
+fi

--- a/docker-compose/docker-compose-local-development.yml
+++ b/docker-compose/docker-compose-local-development.yml
@@ -1,0 +1,13 @@
+services:
+  proxy:
+    volumes:
+      - host:/opt
+    entrypoint: tail -f /dev/null
+
+volumes:
+  host:
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PWD}
+      o: bind


### PR DESCRIPTION
For convenience, I've added a few scripts to make the local development workflow faster. Now you can easily:

- Start/stop all containers
- Start/stop the running proxy process
- Shell into the proxy container to poke around for easier debugging
- Run the tests against the running proxy process

But the most important change, is that for the "local" proxy revision, the current directory is bind mounted to the proxy container so that you can edit with a normal editor on your host, and files will continue to exist if you purge the container.