### PR TITLE
NDEV-2413 statistics: Add new type to allow refunds (negative values)

### DIFF
--- a/proxy/statistic/indexer_service.py
+++ b/proxy/statistic/indexer_service.py
@@ -5,6 +5,7 @@ from aioprometheus import Counter, Gauge, Histogram
 from .data import NeonTxStatData, NeonBlockStatData, NeonDoneBlockStatData
 from .middleware import StatService
 from .stat_data_peeker import StatDataPeeker, IHealthStatService
+from .types import PositiveCounter
 
 from ..common_neon.config import Config
 
@@ -35,7 +36,7 @@ class IndexerStatService(StatService, IHealthStatService):
             'tx_sol_spent', 'LAMPORTs spent on tx execution',
             registry=self._registry
         )
-        self._metr_tx_op_sol_spent = Counter(
+        self._metr_tx_op_sol_spent = PositiveCounter(
             'tx_op_sol_spent', 'LAMPORTs spent by operator on tx execution',
             registry=self._registry
         )

--- a/proxy/statistic/types.py
+++ b/proxy/statistic/types.py
@@ -1,0 +1,15 @@
+from aioprometheus import Counter, Registry
+from aioprometheus.service import Service
+from aioprometheus.mypy_types import LabelsType, NumericValueType
+
+
+class PositiveCounter(Counter):
+    def add(self, labels: LabelsType, amount: NumericValueType) -> None:
+        try:
+            current = self.get(labels)
+        except KeyError:
+            current = 0
+
+        value = current + amount
+
+        self.set(labels, 0 if value < 0 else value)


### PR DESCRIPTION
Prometheus doesn't allow counters to go down, however refunds decrease the Sol spent.