### PR TITLE
NDEV-2535 mempool: Calculate the executable gas-price as a minimal value over N minutes

### DIFF
--- a/proxy/common_neon/config.py
+++ b/proxy/common_neon/config.py
@@ -83,6 +83,7 @@ class Config(DBConfig):
         # Mempool limits
         self._mempool_capacity = self._env_num('MEMPOOL_CAPACITY', 4096, 10, 4096 * 1024)
         self._mempool_executor_limit_cnt = self._env_num('MEMPOOL_EXECUTOR_LIMIT_COUNT', 128, 4, 1024)
+        self._mempool_gas_price_window = self._env_num('MEMPOOL_GAS_PRICE_WINDOW', 10, 1, None)
         self._mempool_cache_life_sec = self._env_num(
             'MEMPOOL_CACHE_LIFE_SEC',
             30 * 60,  # 30 min
@@ -387,6 +388,10 @@ class Config(DBConfig):
     @property
     def mempool_executor_limit_cnt(self) -> int:
         return self._mempool_executor_limit_cnt
+
+    @property
+    def mempool_gas_price_window(self) -> int:
+        return self._mempool_gas_price_window
 
     @property
     def mempool_cache_life_sec(self) -> int:

--- a/proxy/mempool/mempool.py
+++ b/proxy/mempool/mempool.py
@@ -62,7 +62,7 @@ class MemPool:
         self._stat_client = stat_client
 
         self._elf_param_dict_task_loop = MPElfParamDictTaskLoop(executor_mng)
-        self._gas_price_task_loop = MPGasPriceTaskLoop(executor_mng)
+        self._gas_price_task_loop = MPGasPriceTaskLoop(config, executor_mng)
         self._state_tx_cnt_task_loop = MPSenderTxCntTaskLoop(executor_mng, self._tx_schedule)
 
         self._reschedule_time_sec = config.mempool_reschedule_time_sec

--- a/proxy/mempool/mempool_api.py
+++ b/proxy/mempool/mempool_api.py
@@ -337,6 +337,9 @@ class MPGasPriceResult:
     sol_price_account: SolPubKey
     neon_price_account: SolPubKey
 
+    def up_min_executable_gas_price(self, min_executable_gas_price: int) -> None:
+        object.__setattr__(self, 'min_executable_gas_price', min_executable_gas_price)
+
 
 @dataclass(frozen=True)
 class MPElfParamDictResult:

--- a/proxy/mempool/mempool_periodic_task_gas_price.py
+++ b/proxy/mempool/mempool_periodic_task_gas_price.py
@@ -1,18 +1,22 @@
-from typing import Optional
+from typing import List, Optional
 
 from .executor_mng import MPExecutorMng
 from .mempool_api import MPGasPriceRequest, MPGasPriceResult
 from .mempool_periodic_task import MPPeriodicTaskLoop
 
+from ..common_neon.config import Config
 from ..common_neon.constants import ONE_BLOCK_SEC
 
 
 class MPGasPriceTaskLoop(MPPeriodicTaskLoop[MPGasPriceRequest, MPGasPriceResult]):
     _default_sleep_sec = ONE_BLOCK_SEC * 16
 
-    def __init__(self, executor_mng: MPExecutorMng) -> None:
+    def __init__(self, config: Config, executor_mng: MPExecutorMng) -> None:
         super().__init__(name='gas-price', sleep_sec=self._default_sleep_sec, executor_mng=executor_mng)
         self._gas_price: Optional[MPGasPriceResult] = None
+        self._min_executable_gas_prices: List[int] = list()
+        self._min_executable_gas_prices_count: int = int(
+            60 / self._default_sleep_sec * config.mempool_gas_price_window)
 
     @property
     def gas_price(self) -> Optional[MPGasPriceResult]:
@@ -35,4 +39,15 @@ class MPGasPriceTaskLoop(MPPeriodicTaskLoop[MPGasPriceRequest, MPGasPriceResult]
         pass
 
     async def _process_result(self, _: MPGasPriceRequest, mp_res: MPGasPriceResult) -> None:
+        if mp_res.min_executable_gas_price > 0:
+            self._min_executable_gas_prices.append(mp_res.min_executable_gas_price)
+
+            while self._min_executable_gas_prices_count <= len(self._min_executable_gas_prices):
+                self._min_executable_gas_prices.pop(0)
+
+            min_executable_gas_price = min(self._min_executable_gas_prices)
+
+            if min_executable_gas_price > 0:
+                mp_res.up_min_executable_gas_price(min_executable_gas_price)
+
         self._gas_price = mp_res


### PR DESCRIPTION
Since `1.4.x` doesn't process token prices like `1.11.x` does, I had to modify `NDEV-2535` from `develop` to get it working.