### PR TITLE
NDEV-2817 mempool: reject transactions with missing chain Id

### DIFF
--- a/proxy/common_neon/errors.py
+++ b/proxy/common_neon/errors.py
@@ -176,6 +176,10 @@ class NonceTooHighError(RescheduleError):
     def __str__(self) -> str:
         return 'tx nonce is too high for execution'
 
+class InvalidChainIdError(EthereumError):
+    def __init__(self, chain_id: int):
+        super().__init__(f'invalid chain id: {chain_id}')
+
 
 class OutOfGasError(BaseException):
     def __init__(self, has_gas_limit: int, req_gas_limit: int):

--- a/proxy/mempool/gas_price_calculator.py
+++ b/proxy/mempool/gas_price_calculator.py
@@ -114,8 +114,6 @@ class GasPriceCalculator:
             price = self._pyth_network_client.get_price(token_price_symbol)
             if price is None:
                 raise RuntimeError(f'{token_price_symbol} price is absent in the pyth.network list')
-            if price.get('status', 0) != 1:  # tradable
-                raise PythNetworkError(f'{token_price_symbol} price status is not tradable')
             return Decimal(price['price'])
         except PythNetworkError as exc:
             LOG.debug(f'Failed to retrieve {token_price_symbol} price: {str(exc)}')

--- a/proxy/mempool/mempool.py
+++ b/proxy/mempool/mempool.py
@@ -88,6 +88,16 @@ class MemPool(IEVMConfigUser, IGasPriceUser, IMPExecutorMngUser):
 
     def _update_gas_price(self, tx: MPTxRequest) -> Optional[MPTxSendResult]:
         if not tx.has_chain_id():
+            if not self._has_evm_config:
+                LOG.debug("No chain-id supplied while evm config not initialized")
+                return MPTxSendResult(code=MPTxSendResultCode.InvalidChainId, state_tx_cnt=None)
+
+            neon_chain_id = EVMConfig().get_token_info_by_name("NEON").chain_id
+
+            if neon_chain_id is None or EVMConfig().chain_id != neon_chain_id:
+                LOG.debug("No chain-id supplied to non-NEON chain")
+                return MPTxSendResult(code=MPTxSendResultCode.InvalidChainId, state_tx_cnt=None)
+
             LOG.debug("Increase gas-price for wo-chain-id tx")
         elif tx.gas_price == 0:
             LOG.debug("Increase gas-price for gas-less tx")

--- a/proxy/mempool/mempool_api.py
+++ b/proxy/mempool/mempool_api.py
@@ -338,6 +338,7 @@ class MPTxSendResultCode(IntEnum):
     Underprice = 2
     AlreadyKnown = 3
     NonceTooHigh = 4
+    InvalidChainId = 5
     Unspecified = 255
 
 

--- a/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
+++ b/proxy/neon_rpc_api_model/neon_rpc_api_worker.py
@@ -21,7 +21,7 @@ from ..common_neon.config import Config
 from ..common_neon.constants import EVM_PROGRAM_ID_STR
 from ..common_neon.data import NeonTxExecCfg
 from ..common_neon.db.db_connect import DBConnection
-from ..common_neon.errors import EthereumError, InvalidParamError, NonceTooHighError, NonceTooLowError
+from ..common_neon.errors import EthereumError, InvalidChainIdError, InvalidParamError, NonceTooHighError, NonceTooLowError
 from ..common_neon.eth_commit import EthCommit
 from ..common_neon.evm_config import EVMConfig
 from ..common_neon.keys_storage import KeyStorage
@@ -1075,6 +1075,8 @@ class NeonRpcApiWorker:
                 NonceTooLowError.raise_error(neon_tx.hex_sender, neon_tx.nonce, result.state_tx_cnt)
             elif result.code == MPTxSendResultCode.NonceTooHigh:
                 raise NonceTooHighError(result.state_tx_cnt)
+            elif result.code == MPTxSendResultCode.InvalidChainId:
+                raise InvalidChainIdError(neon_tx.chain_id)
             else:
                 raise EthereumError(message='unknown error')
         except BaseException as exc:
@@ -1189,7 +1191,7 @@ class NeonRpcApiWorker:
         return hex(len(tx_list))
 
     @staticmethod
-    def eth_accounts() -> [str]:
+    def eth_accounts() -> List[str]:
         storage = KeyStorage()
         account_list = storage.get_list()
         return [a.checksum_address for a in account_list]


### PR DESCRIPTION
Transactions should be rejected when they do not supply a chain Id to a non-NEON endpoint.

(the NDEV-2873 commit is there because it hasn't been merged into develop yet - waiting for CI fixed)