### PR TITLE
NDEV-2953 mempool: sync sender pool after dropping stuck transaction

### DIFF
--- a/proxy/mempool/mempool_schedule.py
+++ b/proxy/mempool/mempool_schedule.py
@@ -529,6 +529,7 @@ class MPTxSchedule:
 
         self._set_sender_tx_cnt(sender_pool, tx.nonce)
         self._drop_tx_from_sender_pool(sender_pool, tx)
+        self._sync_sender_state(sender_pool)
         return True
 
     @property


### PR DESCRIPTION
We need to sync the sender pool after dropping its stuck transactions.