### PR TITLE
NDEV-2860 neon-core-api: fix number of additional accounts on checking the limit

### DIFF
--- a/proxy/common/constants.py
+++ b/proxy/common/constants.py
@@ -95,6 +95,7 @@ DEFAULT_KEY_FILE = None
 DEFAULT_LOG_FILE = None
 DEFAULT_LOG_FORMAT = '%(asctime)s - pid:%(process)d [%(levelname)-.1s] %(module)s.%(funcName)s:%(lineno)d - %(message)s'
 DEFAULT_LOG_LEVEL = 'INFO'
+DEFAULT_MAX_ACCOUNT_COUNT = 7
 DEFAULT_WEB_ACCESS_LOG_FORMAT = '{client_ip}:{client_port} - ' \
     '{request_method} {request_path} - {request_ua} - {connection_time_ms}ms'
 DEFAULT_HTTP_PROXY_ACCESS_LOG_FORMAT = '{client_ip}:{client_port} - ' + \

--- a/proxy/mempool/neon_tx_send_strategy_alt_stage.py
+++ b/proxy/mempool/neon_tx_send_strategy_alt_stage.py
@@ -2,6 +2,7 @@ import logging
 
 from typing import List, Optional, Dict
 
+from ..common.constants import DEFAULT_MAX_ACCOUNT_COUNT
 from ..common_neon.errors import ALTContentError
 from ..common_neon.solana_alt import ALTInfo
 from ..common_neon.solana_alt_limit import ALTLimit
@@ -148,7 +149,7 @@ def alt_strategy(cls):
             )
 
         def _validate_account_list_len(self) -> bool:
-            len_account_list = self._ctx.len_account_list + 5
+            len_account_list = self._ctx.len_account_list + DEFAULT_MAX_ACCOUNT_COUNT
             if len_account_list < ALTLimit.max_tx_account_cnt:
                 self._validation_error_msg = (
                     f'Number of accounts {len_account_list} less than {ALTLimit.max_tx_account_cnt}'

--- a/proxy/mempool/neon_tx_sender.py
+++ b/proxy/mempool/neon_tx_sender.py
@@ -5,6 +5,7 @@ from ..common_neon.errors import (
     NoMoreRetriesError, TxAccountCntTooBig
 )
 
+from ..common.constants import DEFAULT_MAX_ACCOUNT_COUNT
 from ..common_neon.neon_tx_result_info import NeonTxResultInfo
 
 from .neon_tx_send_base_strategy import BaseNeonTxStrategy
@@ -134,7 +135,7 @@ class NeonTxSendStrategyExecutor:
 
     def _validate_tx_acct_amount(self) -> None:
         # 6 is the base number of account in Neon Instruction. see NeonIxBuilder
-        acct_cnt = self._ctx.len_account_list + 5
+        acct_cnt = self._ctx.len_account_list + DEFAULT_MAX_ACCOUNT_COUNT
         if acct_cnt > self._ctx.config.max_tx_account_cnt:
             raise TxAccountCntTooBig(acct_cnt, self._ctx.config.max_tx_account_cnt)
 

--- a/proxy/neon_rpc_api_model/estimate.py
+++ b/proxy/neon_rpc_api_model/estimate.py
@@ -3,6 +3,7 @@ import math
 
 from typing import Dict, Any, List, Optional
 
+from ..common.constants import DEFAULT_MAX_ACCOUNT_COUNT
 from ..common_neon.evm_config import EVMConfig
 from ..common_neon.data import NeonEmulatorResult, SolanaOverrides
 from ..common_neon.utils.eth_proto import NeonTx
@@ -168,7 +169,7 @@ class GasEstimate:
         """Costs to create->extend->deactivate->close an Address Lookup Table
         """
         # ALT is used by TransactionStepFromAccount, TransactionStepFromAccountNoChainId which have 6 fixed accounts
-        acc_cnt = len(self._account_list) + 5
+        acc_cnt = len(self._account_list) + DEFAULT_MAX_ACCOUNT_COUNT
         if acc_cnt > ALTLimit.max_tx_account_cnt:
             return 5000 * 12  # ALT ix: create + ceil(256/30) extend + deactivate + close
 


### PR DESCRIPTION
Note: this PR is to `develop` so it can be merged into `mainnet` branch. Starting tomorrow I'll start applying changes to the `neon-proxy.py` repo as well (when applicable).

Each Neon transaction has 7 special accounts:

- holder
- operator account for SOL payments
- treasury pool account
- operator account to receive gas payments from a user
- SYS program to create accounts
- EVM program
- ComputeBudget program

This PR creates a constant and updates the old values.